### PR TITLE
feat(homepage): 首頁改版、導覽與全域樣式調整，並加入首頁靜態測試

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,11 +60,22 @@
 }
 
 @layer base {
+  html {
+    scroll-behavior: smooth;
+  }
+
   * {
     @apply border-border;
   }
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-body), sans-serif;
+    text-rendering: optimizeLegibility;
+  }
+
+  .font-display {
+    font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+    letter-spacing: -0.03em;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,36 +1,79 @@
-import ConditionalHeader from '@/components/ConditionalHeader'
+import type { Metadata } from 'next'
+import localFont from 'next/font/local'
+
 import ConditionalFooter from '@/components/ConditionalFooter'
+import ConditionalHeader from '@/components/ConditionalHeader'
+
 import './globals.css'
-import { Inter } from 'next/font/google'
 
-const inter = Inter({ subsets: ['latin'] })
+const geistSans = localFont({
+  src: './fonts/GeistVF.woff',
+  variable: '--font-body',
+  weight: '100 900',
+})
 
-export const metadata = {
+const geistMono = localFont({
+  src: './fonts/GeistMonoVF.woff',
+  variable: '--font-mono',
+  weight: '100 900',
+})
+
+export const metadata: Metadata = {
   title: '青椒老師家教中心 | 清大交大台大等國立大學家教',
-  description: '由清華大學、交通大學畢業生創建的家教媒合平台。提供一對一客製化教學，免費媒合優質家教老師。快速配對、免仲介費、有保障、專業師資。',
-  keywords: ['家教', '找家教', '一對一教學', '免費家教', 
-    '清華大學家教', '交通大學家教', '台灣大學家教', '台師大家教', '家教媒合', '新竹家教',
-    '國小家教', '國中家教', '高中家教', '數學家教', '英文家教', '理化家教', '國小伴讀', '國小全科', '國中全科', '高中全科', '國小數學', '國小英文', '國小理化', '國中數學', '國中英文', '國中理化', '高中數學', '高中英文', '高中理化'],
+  description:
+    '由清華大學、交通大學畢業生創建的家教媒合平台。提供一對一客製化教學，免費媒合優質家教老師。快速配對、免仲介費、有保障、專業師資。',
+  keywords: [
+    '家教',
+    '找家教',
+    '一對一教學',
+    '免費家教',
+    '清華大學家教',
+    '交通大學家教',
+    '台灣大學家教',
+    '台師大家教',
+    '家教媒合',
+    '新竹家教',
+    '國小家教',
+    '國中家教',
+    '高中家教',
+    '數學家教',
+    '英文家教',
+    '理化家教',
+    '國小伴讀',
+    '國小全科',
+    '國中全科',
+    '高中全科',
+    '國小數學',
+    '國小英文',
+    '國小理化',
+    '國中數學',
+    '國中英文',
+    '國中理化',
+    '高中數學',
+    '高中英文',
+    '高中理化',
+  ],
   authors: [{ name: '青椒老師家教中心' }],
   icons: {
     icon: [
       {
         url: '/teacher-icon-192x192.png',
         sizes: '192x192',
-        type: 'image/png'
+        type: 'image/png',
       },
       {
         url: '/teacher-icon-512x512.png',
         sizes: '512x512',
-        type: 'image/png'
-      }
+        type: 'image/png',
+      },
     ],
     shortcut: '/teacher-icon-192x192.png',
     apple: '/teacher-icon-192x192.png',
   },
   openGraph: {
     title: '青椒老師家教中心 | 清大交大台大等國立大學家教',
-    description: '由清華大學、交通大學畢業生創建的家教媒合平台。提供一對一客製化教學，免費媒合優質家教老師。快速配對、免仲介費、有保障、專業師資。',
+    description:
+      '由清華大學、交通大學畢業生創建的家教媒合平台。提供一對一客製化教學，免費媒合優質家教老師。快速配對、免仲介費、有保障、專業師資。',
     url: 'https://tutor-matching.tw',
     siteName: '青椒老師家教中心',
     images: [
@@ -47,7 +90,8 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     title: '青椒老師家教中心',
-    description: '由清華大學、交通大學畢業生創建的家教媒合平台。提供一對一客製化教學，免費媒合優質家教老師。',
+    description:
+      '由清華大學、交通大學畢業生創建的家教媒合平台。提供一對一客製化教學，免費媒合優質家教老師。',
     images: ['https://tutor-matching.tw/teacher-icon-512x512.png'],
   },
   robots: {
@@ -71,9 +115,9 @@ export const metadata = {
 
 export default function RootLayout({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode
-}) {
+}>) {
   return (
     <html lang="zh-TW">
       <head>
@@ -82,14 +126,11 @@ export default function RootLayout({
         <link rel="shortcut icon" type="image/png" href="/teacher-icon-192x192.png" />
         <link rel="apple-touch-icon" href="/teacher-icon-192x192.png" />
       </head>
-      <body className={inter.className }>
+      <body className={`${geistSans.variable} ${geistMono.variable} bg-background text-foreground antialiased`}>
         <ConditionalHeader />
-        <main className="min-h-screen">
-          {children}
-        </main>
+        <main className="min-h-screen">{children}</main>
         <ConditionalFooter />
       </body>
     </html>
   )
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,29 @@
 'use client'
-import Link from 'next/link'
-import Image from 'next/image'
-import { Button } from "@/components/ui/button"
-import TutorCasesClient from './tutor-cases/client'
-import InfiniteCarousel from '@/components/infinite-carousel'
-import { ScrollAnimationWrapper } from '@/hooks/useScrollAnimation'
-import { Users, ArrowRight, Sparkles } from 'lucide-react'
 
-// 圖片路徑
+import Image from 'next/image'
+import Link from 'next/link'
+import type { LucideIcon } from 'lucide-react'
+import {
+  ArrowRight,
+  BadgeCheck,
+  BookOpen,
+  CheckCircle2,
+  ChevronRight,
+  Clock3,
+  FileText,
+  GraduationCap,
+  MapPin,
+  MessageSquare,
+  PhoneCall,
+  Search,
+  ShieldCheck,
+  Sparkles,
+  Users,
+} from 'lucide-react'
+
+import { ScrollAnimationWrapper } from '@/hooks/useScrollAnimation'
+import { Button } from '@/components/ui/button'
+
 const logos = [
   '/logo/image1.png',
   '/logo/image2.png',
@@ -19,250 +35,493 @@ const logos = [
   '/logo/image8.png',
 ]
 
+const trustBadges = [
+  { icon: GraduationCap, label: '清大 / 交大 / 台大等師資' },
+  { icon: ShieldCheck, label: '專人協助配對' },
+  { icon: BadgeCheck, label: '免費媒合評估' },
+]
+
+const advisoryPoints = [
+  '先協助家長整理科目、年級、預算與地點，避免一開始就填太多不必要資訊。',
+  '顧問依照學校背景、教學經驗、時段與交通條件先做第一輪篩選。',
+  '確認合適人選後再安排聯繫，讓家長不用自己逐一詢問與比較。',
+]
+
+const processSteps = [
+  {
+    icon: FileText,
+    title: '告訴我們需求',
+    summary: '填寫孩子的科目、年級、預算與上課方式，我們先幫你整理媒合重點。',
+    helper: '顧問協助釐清需求',
+    outcome: '家長收到需求確認與初步建議',
+  },
+  {
+    icon: Search,
+    title: '顧問篩選老師',
+    summary: '根據學校背景、教學經驗、地區與時段，從合適名單中先做比對與推薦。',
+    helper: '顧問代為比對與聯繫',
+    outcome: '提供符合條件的老師方向與安排方式',
+  },
+  {
+    icon: MessageSquare,
+    title: '安排聯繫與開始上課',
+    summary: '確認雙方條件後安排聯繫，協助家長更順利銜接試教或正式上課。',
+    helper: '顧問陪伴到媒合落地',
+    outcome: '更安心地開始一對一家教',
+  },
+]
+
+const credentialCards = [
+  {
+    title: '師資來源看得見',
+    description: '平台以清大、交大、台大與其他國立大學背景老師為核心，先看學科基礎，再看教學表達與配合度。',
+    points: ['學校與科目背景相符', '教學經驗與溝通能力並重', '依學生程度與目標調整配對'],
+  },
+  {
+    title: '不是只有列名單',
+    description: '我們不是把老師資料直接丟給家長，而是先代做一次篩選與整理，讓媒合更省時間。',
+    points: ['先確認上課地區與時段', '依家長預算縮小選項', '媒合前再確認老師意願'],
+  },
+]
+
+const subjectTags = [
+  '國小伴讀',
+  '國中數學',
+  '國中英文',
+  '高中數學',
+  '高中英文',
+  '自然理化',
+  '學測複習',
+  '會考衝刺',
+]
+
+const supportFaq = [
+  {
+    question: '誰會跟我聯絡？',
+    answer: '會由青椒老師團隊的顧問先與你確認需求，協助整理孩子目前的狀況、希望的上課方式與老師條件。',
+  },
+  {
+    question: '通常多久會開始媒合？',
+    answer: '收到需求後會先進行初步確認，再依照地區、科目與時段安排媒合。可媒合條件越清楚，速度通常越快。',
+  },
+  {
+    question: '如果我不確定該怎麼挑老師？',
+    answer: '這就是顧問存在的目的。我們會先幫你判斷適合的學校背景、教學風格與媒合條件，不需要家長自己從零比較。',
+  },
+  {
+    question: '媒合需要先付費嗎？',
+    answer: '不需要，整個媒合與諮詢流程都完全免費，家長不用支付任何費用即可使用服務。',
+  },
+]
+
+const teacherBenefits = [
+  '查看申請條件與審核流程',
+  '瞭解案件媒合方式與接案節奏',
+  '完成登錄後由平台安排合適案件',
+]
+
+const heroMetrics = [
+  { label: '媒合方式', value: '顧問陪跑' },
+  { label: '師資重點', value: '名校背景' },
+  { label: '開始門檻', value: '先看流程' },
+]
+
+const sectionTitleClass = 'font-display text-3xl leading-tight text-brand-900 md:text-5xl'
+
+const TrustBadge = ({ icon: Icon, label }: { icon: LucideIcon; label: string }) => (
+  <div className="inline-flex min-h-11 items-center gap-2 rounded-full border border-brand-200/70 bg-white/90 px-4 py-2 text-sm font-medium text-brand-800 shadow-[0_10px_30px_rgba(66,122,91,0.08)] backdrop-blur">
+    <Icon className="h-4 w-4 text-brand-600" />
+    <span>{label}</span>
+  </div>
+)
+
+const ProcessCard = ({
+  icon: Icon,
+  index,
+  title,
+  summary,
+  helper,
+  outcome,
+}: {
+  icon: LucideIcon
+  index: number
+  title: string
+  summary: string
+  helper: string
+  outcome: string
+}) => (
+  <div className="relative rounded-[2rem] border border-brand-100 bg-white px-6 py-7 shadow-[0_24px_80px_rgba(67,102,78,0.08)]">
+    <div className="mb-5 flex items-center justify-between">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-100 text-brand-700">
+        <Icon className="h-5 w-5" />
+      </div>
+      <span className="text-sm font-semibold tracking-[0.24em] text-brand-300">0{index}</span>
+    </div>
+    <h3 className="mb-3 text-xl font-semibold text-brand-900">{title}</h3>
+    <p className="mb-5 text-sm leading-7 text-neutral-600">{summary}</p>
+    <div className="space-y-3 rounded-[1.5rem] bg-[#f8f5ea] p-4 text-sm text-neutral-700">
+      <div className="flex gap-3">
+        <Users className="mt-0.5 h-4 w-4 flex-none text-brand-600" />
+        <span>{helper}</span>
+      </div>
+      <div className="flex gap-3">
+        <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none text-brand-600" />
+        <span>{outcome}</span>
+      </div>
+    </div>
+  </div>
+)
+
+const FaqItem = ({ question, answer }: { question: string; answer: string }) => (
+  <details className="group rounded-[1.75rem] border border-brand-100 bg-white px-5 py-4 shadow-[0_12px_40px_rgba(67,102,78,0.06)]">
+    <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-left text-base font-semibold text-brand-900 [&::-webkit-details-marker]:hidden">
+      <span>{question}</span>
+      <ChevronRight className="h-5 w-5 flex-none text-brand-500 transition-transform duration-300 group-open:rotate-90" />
+    </summary>
+    <p className="pt-4 text-sm leading-7 text-neutral-600">{answer}</p>
+  </details>
+)
+
 export default function Home() {
   return (
-    <div className="bg-white">
-      {/* Hero Section */}
-      <section className="h-[calc(100vh-80px)] flex items-center justify-center bg-gradient-to-br from-brand-50 to-brand-100">
-        <div className="container px-6 mx-auto text-center max-w-4xl">
-          {/* Profile Image */}
-          <div className="mb-8 relative">
-                         {/* 聊天泡泡 */}
-             <div className="absolute -top-8 left-1/2 transform -translate-x-1/2 z-10">
-               <Link href="/solver" className="group">
-                 <div className="bg-white rounded-2xl px-4 py-3 shadow-lg border border-neutral-200 hover:shadow-xl transition-all duration-300 hover:scale-105">
-                   <div className="flex items-center space-x-2">
-                                           <span className="text-sm font-medium text-neutral-800 whitespace-nowrap">點擊進入青椒老師解題AI</span>
-                                           <div className="w-2 h-2 bg-brand-400 rounded-full animate-pulse flex-shrink-0"></div>
-                   </div>
-                   {/* 聊天泡泡的小三角形 */}
-                   <div className="absolute -bottom-2 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-t-[8px] border-t-white"></div>
-                 </div>
-               </Link>
-             </div>
-            
-            {/* Profile Image */}
-            <div className="w-48 h-48 mx-auto mb-4 relative">
-              <Link href="/solver" className="group">
-                <Image 
-                  src="/teacher-icon.png" 
-                  alt="青椒老師家教中心" 
-                  width={192}
-                  height={192}
-                  className="w-full h-full object-cover rounded-full cursor-pointer transition-transform duration-300 group-hover:scale-105"
-                />
-              </Link>
+    <div className="relative overflow-hidden bg-[#f7f3e8] text-neutral-900">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-[34rem] bg-[radial-gradient(circle_at_top_left,_rgba(180,205,147,0.46),_transparent_48%),radial-gradient(circle_at_top_right,_rgba(66,122,91,0.18),_transparent_34%)]" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-full bg-[linear-gradient(180deg,rgba(255,255,255,0.38),transparent_24%,transparent_76%,rgba(255,255,255,0.18))]" />
+
+      <section className="relative px-4 pb-6 pt-6 sm:px-6 lg:px-8 lg:pt-10">
+        <div className="mx-auto max-w-6xl">
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,1.15fr)_22rem] lg:items-stretch lg:gap-8">
+            <ScrollAnimationWrapper className="rounded-[2rem] border border-white/70 bg-[linear-gradient(145deg,rgba(255,255,255,0.96),rgba(245,250,242,0.9))] p-6 shadow-[0_30px_90px_rgba(67,102,78,0.12)] md:p-8 lg:h-full lg:p-10" duration={900}>
+              <div className="flex h-full flex-col">
+                <div className="mb-5 inline-flex w-auto max-w-max items-center gap-2 rounded-full border border-brand-200 bg-brand-50/80 px-4 py-2 text-xs font-semibold tracking-[0.28em] text-brand-700">
+                  <Sparkles className="h-4 w-4" />
+                  專業家教媒合
+                </div>
+                <h1 className="font-display max-w-3xl text-[2.35rem] leading-[1.05] text-brand-900 sm:text-5xl lg:text-[4.0rem]">
+                  先安心，再幫孩子找到適合的老師
+                </h1>
+                <p className="mt-5 max-w-2xl text-base leading-8 text-neutral-600 sm:text-lg">
+                  想找優質又安心的家教？我們嚴選名校師資，媒合顧問親自協助，服務流程透明，保障每位家長的需求。讓您不用花時間篩選、不必擔心踩雷，我們幫您把關每一個細節，最快速度找到最適合孩子的專業老師！
+                </p>
+
+                <div className="mt-6 flex flex-wrap gap-3">
+                  {trustBadges.map((badge) => (
+                    <TrustBadge key={badge.label} {...badge} />
+                  ))}
+                </div>
+
+                <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                  <Button
+                    asChild
+                    size="lg"
+                    className="min-h-12 rounded-full bg-brand-500 px-6 text-base font-semibold text-white shadow-[0_18px_45px_rgba(66,122,91,0.28)] transition-transform duration-300 hover:-translate-y-0.5 hover:bg-brand-600"
+                  >
+                    <a href="#process">
+                      先看媒合流程
+                      <ArrowRight className="h-4 w-4" />
+                    </a>
+                  </Button>
+                  <Button
+                    asChild
+                    size="lg"
+                    variant="outline"
+                    className="min-h-12 rounded-full border-brand-300 bg-white/80 px-6 text-base font-semibold text-brand-800 shadow-[0_12px_32px_rgba(66,122,91,0.08)] hover:bg-brand-50"
+                  >
+                    <Link href="/case-upload">
+                      直接填需求
+                      <ChevronRight className="h-4 w-4" />
+                    </Link>
+                  </Button>
+                </div>
+
+                <div className="mt-8 grid gap-3 sm:grid-cols-3 lg:mt-auto lg:pt-8">
+                  {heroMetrics.map((metric) => (
+                    <div key={metric.label} className="rounded-[1.5rem] border border-brand-100 bg-white/80 px-4 py-4 shadow-[0_12px_32px_rgba(66,122,91,0.06)]">
+                      <div className="text-xs uppercase tracking-[0.24em] text-brand-400">{metric.label}</div>
+                      <div className="mt-2 text-lg font-semibold text-brand-900">{metric.value}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </ScrollAnimationWrapper>
+
+            <ScrollAnimationWrapper className="rounded-[2rem] border border-brand-100 bg-[#fffdf8]/95 p-5 shadow-[0_28px_70px_rgba(67,102,78,0.1)] backdrop-blur md:p-6 lg:h-full" delay={180} duration={900}>
+              <div className="grid h-full gap-6 lg:grid-rows-[auto_1fr]">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-100">
+                    <Image src="/teacher-icon-512x512.png" alt="青椒老師家教中心" width={32} height={32} className="h-8 w-8" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-brand-700">媒合顧問會先幫你整理重點</p>
+                    <p className="text-sm text-neutral-500">不是丟一串老師名單讓家長自己挑</p>
+                  </div>
+                </div>
+
+                <div className="flex h-full flex-col justify-between gap-6">
+                  <div className="space-y-4">
+                    {advisoryPoints.map((point) => (
+                      <div key={point} className="flex gap-3 rounded-[1.35rem] bg-[#f5f1e4] px-4 py-4 text-sm leading-7 text-neutral-700">
+                        <CheckCircle2 className="mt-1 h-4 w-4 flex-none text-brand-600" />
+                        <span>{point}</span>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="rounded-[1.5rem] border border-brand-100 bg-white p-5">
+                    <div className="flex items-center gap-3 text-sm font-semibold text-brand-700">
+                      <Clock3 className="h-4 w-4" />
+                      家長最常先看的 3 件事
+                    </div>
+                    <div className="mt-4 space-y-3 text-sm text-neutral-600">
+                      <div className="flex items-center justify-between gap-3 border-b border-brand-100 pb-3">
+                        <span>師資背景是否符合需求</span>
+                        <span className="font-semibold text-brand-800">先篩選</span>
+                      </div>
+                      <div className="flex items-center justify-between gap-3 border-b border-brand-100 pb-3">
+                        <span>流程是否清楚、有沒有人協助</span>
+                        <span className="font-semibold text-brand-800">會說明</span>
+                      </div>
+                      <div className="flex items-center justify-between gap-3">
+                        <span>還沒準備好時可先看工具</span>
+                        <span className="font-semibold text-brand-800">AI 解題</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </ScrollAnimationWrapper>
+          </div>
+
+          <ScrollAnimationWrapper className="mt-5" delay={240} duration={900}>
+            <div className="rounded-[2rem] border border-brand-100 bg-[linear-gradient(135deg,rgba(242,247,238,0.96),rgba(255,255,255,0.92))] p-6 shadow-[0_24px_70px_rgba(67,102,78,0.08)] md:p-7">
+              <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+                <div className="max-w-2xl">
+                  <p className="text-sm font-semibold tracking-[0.28em] text-brand-500">TEACHER PATH</p>
+                  <h2 className="mt-2 font-display text-2xl text-brand-900 md:text-3xl">想開始接家教案件？查看流程與申請條件</h2>
+                  <p className="mt-3 text-sm leading-7 text-neutral-600 md:text-base">
+                    首頁主線先服務家長，但老師入口會保留在第一段。你可以先看平台審核方式、案件節奏與登錄條件，再決定是否加入。
+                  </p>
+                </div>
+                <div className="rounded-[1.5rem] bg-white/90 p-4 shadow-[0_18px_40px_rgba(67,102,78,0.06)] md:max-w-sm">
+                  <div className="space-y-3 text-sm text-neutral-700">
+                    {teacherBenefits.map((benefit) => (
+                      <div key={benefit} className="flex gap-3">
+                        <BadgeCheck className="mt-0.5 h-4 w-4 flex-none text-brand-600" />
+                        <span>{benefit}</span>
+                      </div>
+                    ))}
+                  </div>
+                  <Button asChild variant="outline" className="mt-5 min-h-11 w-full rounded-full border-brand-300 bg-white text-brand-800 hover:bg-brand-50">
+                    <Link href="/tutor-registration">
+                      前往教師登錄
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  </Button>
+                </div>
+              </div>
             </div>
-          </div>
-          
-          {/* Main Title */}
-          <h1 className="text-4xl md:text-6xl font-bold text-neutral-900 mb-6 leading-tight">
-            為孩子找到<br />
-            最適合的<span className="text-brand-600">家教老師</span>
-          </h1>
-          
-          <p className="text-xl text-neutral-600 mb-12 max-w-2xl mx-auto">
-            由清華大學、交通大學畢業生創建的家教平台<br />
-            幫助家長根據需求找到最適合的家教老師
-          </p>
-          
-          {/* 超級醒目的 CTA Button */}
-          <div className="relative">
-            {/* 背景光暈效果 */}
-            <div className="absolute inset-0 -m-4 "></div>
-            
-            <Link href="/case-upload" className="relative block">
-              <Button 
-                size="lg" 
-                className="relative overflow-hidden bg-gradient-to-r from-green-500 via-emerald-600 to-teal-600 hover:from-green-600 hover:via-emerald-700 hover:to-teal-700 text-white font-bold px-12 py-6 rounded-full text-xl shadow-2xl hover:shadow-3xl transform hover:-translate-y-1 transition-all duration-300 hover:scale-105 border-2 border-white/20"
-              >
-                {/* 按鈕內部光效 */}
-                <div className="absolute inset-0 bg-gradient-to-r from-white/0 via-white/20 to-white/0 -translate-x-full group-hover:translate-x-full transition-transform duration-1000"></div>
-                
-                {/* 閃爍效果 */}
-                <div className="absolute top-0 left-0 w-full h-full">
-                  <Sparkles className="absolute top-2 left-4 w-4 h-4 text-white/80 animate-pulse" />
-                  <Sparkles className="absolute bottom-2 right-6 w-3 h-3 text-yellow-200 animate-pulse" style={{animationDelay: '1s'}} />
-                </div>
-                
-                <div className="relative flex items-center justify-center space-x-3">
-                  <Users className="w-6 h-6" />
-                  <span className="font-extrabold tracking-wide">家長找家教</span>
-                  <ArrowRight className="w-6 h-6 transition-transform group-hover:translate-x-1" />
-                </div>
-                
-              </Button>
-            </Link>
-          </div>
+          </ScrollAnimationWrapper>
         </div>
       </section>
 
-      {/* Partners Section */}
       <ScrollAnimationWrapper>
-        <section className="py-20 bg-white">
-          <div className="container px-6 mx-auto max-w-6xl">
-            <ScrollAnimationWrapper delay={200}>
-              <div className="text-center mb-16">
-                <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 mb-4">
-                  許多頂尖大學老師
-                </h2>
-                <p className="text-neutral-600 text-lg">
-                  為學生提供最優質的教育資源
-                </p>
-              </div>
-            </ScrollAnimationWrapper>
-            
-            {/* Logo Carousel */}
-            <ScrollAnimationWrapper delay={400}>
-              {/* 桌面版：標準大小輪播 */}
-              <div className="hidden md:block">
-                <InfiniteCarousel 
-                  images={logos}
-                  speed={0.1}
-                  className="my-8"
-                />
-              </div>
-              
-              {/* 手機版：大尺寸輪播 */}
-              <div className="md:hidden">
-                <InfiniteCarousel 
-                  images={logos}
-                  speed={0.3}
-                  imageWidth={180}
-                  imageHeight={90}
-                  className="my-8"
-                />
-              </div>
-            </ScrollAnimationWrapper>
-          </div>
-        </section>
-      </ScrollAnimationWrapper>
+        <section id="process" className="scroll-mt-28 px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
+          <div className="mx-auto max-w-6xl">
+            <div className="max-w-3xl">
+              <p className="text-sm font-semibold tracking-[0.28em] text-brand-500">PROCESS</p>
+              <h2 className={`${sectionTitleClass} mt-3`}>先看懂流程，再決定要不要填需求</h2>
+            </div>
 
-      {/* Services Section */}
-      <ScrollAnimationWrapper>
-        <section className="py-20 bg-neutral-50">
-          <div className="container px-6 mx-auto max-w-6xl">
-            <ScrollAnimationWrapper delay={200}>
-              <div className="text-center mb-16">
-                <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 mb-4">
-                  我們的服務
-                </h2>
-                <p className="text-neutral-600 text-lg">
-                  提供全方位的教育解決方案
+            <div className="mt-8 grid gap-4 lg:grid-cols-3 lg:gap-5">
+              {processSteps.map((step, index) => (
+                <ScrollAnimationWrapper key={step.title} delay={180 + index * 120} duration={900}>
+                  <ProcessCard index={index + 1} {...step} />
+                </ScrollAnimationWrapper>
+              ))}
+            </div>
+
+            <div className="mt-8 flex flex-col gap-3 rounded-[2rem] bg-brand-900 px-6 py-7 text-white shadow-[0_28px_80px_rgba(31,58,45,0.22)] md:flex-row md:items-center md:justify-between md:px-8">
+              <div>
+                <p className="text-sm font-semibold tracking-[0.28em] text-brand-200">READY TO START</p>
+                <h3 className="mt-2 font-display text-2xl md:text-3xl">流程清楚了，現在就可以填寫需求表</h3>
+                <p className="mt-2 max-w-2xl text-sm leading-7 text-brand-100 md:text-base">
+                  先告訴我們孩子目前的學習狀況與家長希望，我們再依條件協助安排適合的老師方向。
                 </p>
               </div>
-            </ScrollAnimationWrapper>
-            
-            <div className="grid md:grid-cols-4 gap-8">
-              <ScrollAnimationWrapper delay={400}>
-                <div className="text-center p-6">
-                  <div className="w-16 h-16 bg-brand-100 rounded-full mx-auto mb-4 flex items-center justify-center">
-                    <svg className="w-8 h-8 text-brand-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                    </svg>
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-900 mb-2">AI解題機器人</h3>
-                  <p className="text-neutral-600 text-sm">
-                    上傳題目照片馬上獲得詳解，問到會為止，全部免費
-                  </p>
-                </div>
-              </ScrollAnimationWrapper>
-              
-              <ScrollAnimationWrapper delay={500}>
-                <div className="text-center p-6">
-                  <div className="w-16 h-16 bg-brand-200 rounded-full mx-auto mb-4 flex items-center justify-center">
-                    <svg className="w-8 h-8 text-brand-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-                    </svg>
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-900 mb-2">最適化配對</h3>
-                  <p className="text-neutral-600 text-sm">
-                    根據學生需求以及家教老師的專長，找到最適合的配對
-                  </p>
-                </div>
-              </ScrollAnimationWrapper>
-              
-              <ScrollAnimationWrapper delay={600}>
-                <div className="text-center p-6">
-                  <div className="w-16 h-16 bg-brand-100 rounded-full mx-auto mb-4 flex items-center justify-center">
-                    <svg className="w-8 h-8 text-brand-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                    </svg>
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-900 mb-2">讀書計畫</h3>
-                  <p className="text-neutral-600 text-sm">
-                    提供免費的會考以及學測讀書計畫，幫助學生更有效學習
-                  </p>
-                </div>
-              </ScrollAnimationWrapper>
-              
-              <ScrollAnimationWrapper delay={700}>
-                <div className="text-center p-6">
-                  <div className="w-16 h-16 bg-brand-200 rounded-full mx-auto mb-4 flex items-center justify-center">
-                    <svg className="w-8 h-8 text-brand-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                    </svg>
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-900 mb-2">快速媒合</h3>
-                  <p className="text-neutral-600 text-sm">
-                    專業團隊快速為您找到合適的家教老師，無須支付任何費用
-                  </p>
-                </div>
-              </ScrollAnimationWrapper>
+              <Button asChild size="lg" className="min-h-12 rounded-full bg-[#dfeecf] px-6 text-base font-semibold text-brand-900 hover:bg-[#cfe5b8]">
+                <Link href="/case-upload">
+                  填寫需求表
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
             </div>
           </div>
         </section>
       </ScrollAnimationWrapper>
 
-      {/* CTA Section */}
       <ScrollAnimationWrapper>
-        <section className="py-20 bg-white">
-          <div className="container px-6 mx-auto text-center max-w-4xl">
-            <ScrollAnimationWrapper delay={200}>
-              <div className="mb-8">
-                <div className="w-16 h-16 bg-brand-100 rounded-full mx-auto mb-4 flex items-center justify-center">
-                  <svg className="w-8 h-8 text-brand-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                  </svg>
+        <section className="px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
+          <div className="mx-auto max-w-6xl rounded-[2.25rem] border border-white/70 bg-[linear-gradient(145deg,rgba(255,255,255,0.96),rgba(245,249,242,0.92))] p-6 shadow-[0_32px_100px_rgba(67,102,78,0.08)] md:p-8 lg:p-10">
+            <div className="grid gap-10 lg:grid-cols-[minmax(0,1.05fr)_0.95fr] lg:items-start">
+              <div>
+                <p className="text-sm font-semibold tracking-[0.28em] text-brand-500">CREDENTIALS</p>
+                <h2 className={`${sectionTitleClass} mt-3`}>值得信賴的師資陣容</h2>
+                <p className="mt-4 max-w-2xl text-base leading-8 text-neutral-600">
+                  每一位教學夥伴都經過嚴格篩選，不僅具備專業學歷，更重視教學經驗與溝通能力。我們真誠傾聽每個孩子的需求，並且定期追蹤上課情形，確保每位老師都能成為家長與學生信賴的夥伴。選擇我們，就是選擇安心與責任感兼具的師資團隊。
+                </p>
+
+                <div className="mt-6 grid gap-4 md:grid-cols-2">
+                  {credentialCards.map((card) => (
+                    <div key={card.title} className="rounded-[1.75rem] border border-brand-100 bg-[#fffdf8] p-5 shadow-[0_18px_45px_rgba(67,102,78,0.05)]">
+                      <h3 className="text-xl font-semibold text-brand-900">{card.title}</h3>
+                      <p className="mt-3 text-sm leading-7 text-neutral-600">{card.description}</p>
+                      <div className="mt-4 space-y-3 text-sm text-neutral-700">
+                        {card.points.map((point) => (
+                          <div key={point} className="flex gap-3">
+                            <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none text-brand-600" />
+                            <span>{point}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </div>
-            </ScrollAnimationWrapper>
-            
-            <ScrollAnimationWrapper delay={400}>
-              <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 mb-6">
-                告訴我們您的需求
-              </h2>
-            </ScrollAnimationWrapper>
-            
-            <ScrollAnimationWrapper delay={600}>
-              <p className="text-xl text-neutral-600 mb-12">
-                讓我們為您的孩子找到最適合的學習夥伴
-              </p>
-            </ScrollAnimationWrapper>
-            
-            <ScrollAnimationWrapper delay={800}>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <Link href="/case-upload">
-                  <Button size="lg" className="bg-brand-500 text-white hover:bg-brand-600 px-8 py-4 rounded-full text-lg font-medium transition-colors">
-                    開始諮詢
-                  </Button>
-                </Link>
-                <Link href="/tutor-cases">
-                  <Button size="lg" variant="outline" className="border-brand-300 text-brand-700 hover:bg-brand-50 px-8 py-4 rounded-full text-lg font-medium transition-colors">
-                    瀏覽案件
-                  </Button>
-                </Link>
+
+              <div className="space-y-5">
+                <div className="rounded-[1.85rem] border border-brand-100 bg-white p-5 shadow-[0_18px_50px_rgba(67,102,78,0.06)]">
+                  <div className="flex items-center gap-3 text-sm font-semibold text-brand-700">
+                    <GraduationCap className="h-4 w-4" />
+                    常見師資背景來源
+                  </div>
+                  <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+                    {logos.map((logo, index) => (
+                      <div key={logo} className="flex h-20 items-center justify-center rounded-[1.2rem] border border-brand-100 bg-[#f8f5ea] p-3">
+                        <Image
+                          src={logo}
+                          alt={`合作師資學校 ${index + 1}`}
+                          width={110}
+                          height={44}
+                          className="h-10 w-auto object-contain"
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-[1.85rem] border border-brand-100 bg-white p-5 shadow-[0_18px_50px_rgba(67,102,78,0.06)]">
+                  <div className="flex items-center gap-3 text-sm font-semibold text-brand-700">
+                    <BookOpen className="h-4 w-4" />
+                    常見媒合需求
+                  </div>
+                  <div className="mt-4 flex flex-wrap gap-2.5">
+                    {subjectTags.map((tag) => (
+                      <span key={tag} className="rounded-full bg-brand-50 px-3 py-2 text-sm font-medium text-brand-700">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="mt-5 rounded-[1.4rem] bg-[#f8f5ea] p-4 text-sm leading-7 text-neutral-700">
+                    媒合時會一起看科目能力、教學表達、可配合時段與地區，讓推薦更接近家長的真實需求。
+                  </div>
+                </div>
               </div>
-            </ScrollAnimationWrapper>
+            </div>
           </div>
         </section>
       </ScrollAnimationWrapper>
 
-      {/* Cases Section */}
       <ScrollAnimationWrapper>
-        <section className="py-20 bg-neutral-50">
-          <div className="container px-6 mx-auto max-w-6xl">
-            <TutorCasesClient />
+        <section className="px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
+          <div className="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[0.92fr_1.08fr] lg:items-start">
+            <div className="rounded-[2rem] bg-brand-900 p-6 text-white shadow-[0_30px_90px_rgba(31,58,45,0.2)] md:p-8">
+              <p className="text-sm font-semibold tracking-[0.28em] text-brand-200">GUIDED SUPPORT</p>
+              <h2 className="mt-3 font-display text-3xl leading-tight md:text-5xl">有人協助，才是家長真正想要的安心感</h2>
+              <p className="mt-4 text-sm leading-8 text-brand-100 md:text-base">
+                找家教不安心？讓專業顧問全程協助您！孩子的獨特需求、學習困難、家長的期望，我們都細心聆聽。從理解狀況、條件整理到推薦合適老師，一對一陪伴家長做出最適合孩子的選擇。您只需要把需求放心交給我們，其他都交由專人打點，把最適合的家教帶到您身邊。
+              </p>
+
+              <div className="mt-6 space-y-4 rounded-[1.75rem] bg-white/8 p-5 text-sm leading-7 text-brand-50 backdrop-blur">
+                <div className="flex gap-3">
+                  <PhoneCall className="mt-1 h-4 w-4 flex-none text-brand-200" />
+                  <span>顧問先聯絡確認孩子狀況與家長期待，避免一開始就選錯方向。</span>
+                </div>
+                <div className="flex gap-3">
+                  <MapPin className="mt-1 h-4 w-4 flex-none text-brand-200" />
+                  <span>上課地點、線上或實體、每週時段等實際條件，會在媒合前先幫你整理。</span>
+                </div>
+                <div className="flex gap-3">
+                  <Users className="mt-1 h-4 w-4 flex-none text-brand-200" />
+                  <span>你看到的不是原始名單，而是更接近需求、可開始討論的老師方向。</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              {supportFaq.map((item) => (
+                <FaqItem key={item.question} {...item} />
+              ))}
+            </div>
+          </div>
+        </section>
+      </ScrollAnimationWrapper>
+
+      <ScrollAnimationWrapper>
+        <section className="px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
+          <div className="mx-auto max-w-6xl rounded-[2rem] border border-brand-100 bg-[linear-gradient(135deg,rgba(237,244,228,0.95),rgba(255,255,255,0.9))] p-6 shadow-[0_26px_90px_rgba(67,102,78,0.08)] md:p-8">
+            <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+              <div>
+                <p className="text-sm font-semibold tracking-[0.28em] text-brand-500">AI STUDY TOOL</p>
+                <h2 className="mt-3 font-display text-3xl text-brand-900 md:text-4xl">還沒準備找老師？先用 AI 解題看看</h2>
+                <p className="mt-4 text-base leading-8 text-neutral-600">
+                  不確定孩子卡在哪裡、還沒準備找家教？讓青椒老師的 AI 幫你解題，快速搞懂孩子遇到的難題。先有解決方法，家長才能更清楚下一步需要什麼協助。
+                </p>
+              </div>
+              <div className="rounded-[1.75rem] border border-brand-100 bg-white/95 p-5 shadow-[0_18px_50px_rgba(67,102,78,0.06)]">
+                <div className="flex items-start gap-4">
+                  <div>
+                    <h3 className="text-xl font-semibold text-brand-900">青椒老師解題 AI</h3>
+                    <p className="mt-2 text-sm leading-7 text-neutral-600">
+                      孩子在學習上遇到瓶頸，讓 AI 高手幫你迅速解題、解析每一步。家長能親自體驗詳細解說，立刻知道青椒老師如何協助孩子突破難題，先感受到專業與用心，才放心決定下一步。
+                    </p>
+                  </div>
+                </div>
+                <Button asChild variant="outline" className="mt-5 min-h-12 w-full rounded-full border-brand-300 bg-white text-brand-800 hover:bg-brand-50">
+                  <Link href="/solver">
+                    前往 AI 解題
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </ScrollAnimationWrapper>
+
+      <ScrollAnimationWrapper>
+        <section className="px-4 pb-20 pt-14 sm:px-6 lg:px-8 lg:pb-24 lg:pt-20">
+          <div className="mx-auto max-w-6xl rounded-[2.2rem] bg-[linear-gradient(145deg,#234430,#427a5b)] px-6 py-8 text-white shadow-[0_40px_120px_rgba(31,58,45,0.22)] md:px-8 md:py-10">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+              <div className="max-w-3xl">
+                <p className="text-sm font-semibold tracking-[0.28em] text-brand-100">FINAL STEP</p>
+                <h2 className="mt-3 font-display text-3xl leading-tight md:text-5xl">看完流程後，現在可以安心開始填需求</h2>
+                <p className="mt-4 text-sm leading-8 text-brand-100 md:text-base">
+                  你不需要先自己把所有老師都看過一輪。先告訴我們孩子的情況，剩下的媒合整理工作交給顧問協助完成。
+                </p>
+              </div>
+              <div className="flex w-full flex-col gap-3 lg:w-auto lg:min-w-[16rem]">
+                <Button asChild size="lg" className="min-h-12 rounded-full bg-[#e3f2d2] text-base font-semibold text-brand-900 hover:bg-[#d4e9bc]">
+                  <Link href="/case-upload">
+                    立即填需求
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </Button>
+                <Link href="/tutor-registration" className="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-5 py-3 text-sm font-medium text-white/88 transition-colors hover:bg-white/10">
+                  老師想加入平台？前往教師登錄
+                  <ChevronRight className="h-4 w-4" />
+                </Link>
+              </div>
+            </div>
           </div>
         </section>
       </ScrollAnimationWrapper>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,14 +1,25 @@
 "use client"
 
-import Link from 'next/link'
 import Image from 'next/image'
-import { useState, useEffect, useRef } from 'react'
+import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
+import { ChevronRight, Menu, X } from 'lucide-react'
+
+const primaryMobileLinks = [
+  { href: '/case-upload', label: '填需求', description: '家長入口' },
+  { href: '/tutor-registration', label: '教師登錄', description: '老師入口' },
+]
+
+const secondaryMobileLinks = [
+  { href: '/tutors', label: '家教老師' },
+  { href: '/tutor-cases', label: '案件專區' },
+  { href: '/solver', label: 'AI解題' },
+]
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const headerRef = useRef<HTMLElement>(null)
 
-  // 點擊外部區域和按 ESC 鍵關閉選單
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (headerRef.current && !headerRef.current.contains(event.target as Node)) {
@@ -22,13 +33,11 @@ export default function Header() {
       }
     }
 
-    // 只在選單打開時添加事件監聽器
     if (isMenuOpen) {
       document.addEventListener('mousedown', handleClickOutside)
       document.addEventListener('keydown', handleEscKey)
     }
 
-    // 清理事件監聽器
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
       document.removeEventListener('keydown', handleEscKey)
@@ -36,127 +45,90 @@ export default function Header() {
   }, [isMenuOpen])
 
   return (
-    <header ref={headerRef} className="bg-white border-b border-neutral-100 py-6 relative">
-      <div className="container px-6 mx-auto max-w-6xl">
-        {/* 統一排列 - 品牌名稱靠左，選單/按鈕靠右 */}
-        <div className="flex justify-between items-center">
-          <Link href="/" className="flex items-center space-x-3 text-xl font-semibold text-gray-900 flex-shrink-0">
-            <Image 
-              src="/teacher-icon-512x512.png" 
-              alt="青椒老師家教中心" 
-              width={32}
-              height={32}
-              className="w-8 h-8"
-            />
-            <span>青椒老師家教中心</span>
+    <header ref={headerRef} className="sticky top-0 z-40 border-b border-brand-100/70 bg-[#fbfaf4]/90 backdrop-blur-xl">
+      <div className="container mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="flex min-h-[76px] items-center justify-between gap-3">
+          <Link href="/" className="flex min-w-0 items-center gap-1 text-brand-900">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl">
+              <Image
+                src="/teacher-icon-512x512.png"
+                alt="青椒老師家教中心"
+                width={30}
+                height={30}
+                className="h-8 w-8"
+              />
+            </div>
+            <div className="min-w-0">
+              <div className="truncate text-base font-semibold md:text-lg">青椒老師家教中心</div>
+              <div className="hidden text-xs tracking-[0.18em] text-brand-500 sm:block">TUTOR MATCHING CONSULTING</div>
+            </div>
           </Link>
-          
-          {/* 桌面版選單 */}
-          <nav className="hidden md:block">
-            <ul className="flex items-center space-x-8">
-              <li><Link href="/tutors" className="text-neutral-600 hover:text-brand-700 transition-colors">家教老師</Link></li>
-              <li><Link href="/tutor-cases" className="text-neutral-600 hover:text-brand-700 transition-colors">案件專區</Link></li>
-              <li><Link href="/solver" className="text-neutral-600 hover:text-brand-700 transition-colors">AI解題</Link></li>
-              <li><Link href="/tutor-registration" className="text-neutral-600 hover:text-brand-700 transition-colors">教師登錄</Link></li>
-              <li>
-                <Link href="/case-upload" className="bg-brand-500 text-white px-6 py-2 rounded-full hover:bg-brand-600 transition-colors inline-block">
-                  找家教
-                </Link>
-              </li>
-            </ul>
+
+          <nav className="hidden items-center gap-7 md:flex">
+            <Link href="/tutors" className="text-sm font-medium text-neutral-600 transition-colors hover:text-brand-700">家教老師</Link>
+            <Link href="/tutor-cases" className="text-sm font-medium text-neutral-600 transition-colors hover:text-brand-700">案件專區</Link>
+            <Link href="/solver" className="text-sm font-medium text-neutral-600 transition-colors hover:text-brand-700">AI解題</Link>
+            <Link href="/tutor-registration" className="text-sm font-medium text-neutral-600 transition-colors hover:text-brand-700">教師登錄</Link>
+            <Link href="/case-upload" className="inline-flex min-h-11 items-center rounded-full bg-brand-500 px-5 text-sm font-semibold text-white shadow-[0_16px_32px_rgba(66,122,91,0.2)] transition-colors hover:bg-brand-600">
+              填需求
+            </Link>
           </nav>
 
-          {/* 漢堡選單按鈕 - 只在小螢幕顯示 */}
-          <button 
-            className="text-neutral-600 md:hidden p-2 flex-shrink-0 transition-transform duration-200"  
-            onClick={() => setIsMenuOpen(!isMenuOpen)}
-          >
-            <svg 
-              className={`w-6 h-6 transition-transform duration-200 ${isMenuOpen ? 'rotate-90' : 'rotate-0'}`}
-              fill="none" 
-              stroke="currentColor" 
-              viewBox="0 0 24 24"
+          <div className="flex items-center gap-2 md:hidden">
+            <Link href="/case-upload" className="inline-flex min-h-11 items-center rounded-full border border-brand-200 bg-white px-4 text-sm font-semibold text-brand-800 shadow-[0_10px_24px_rgba(66,122,91,0.08)] transition-colors hover:bg-brand-50">
+              填需求
+            </Link>
+            <button
+              type="button"
+              aria-expanded={isMenuOpen}
+              aria-label={isMenuOpen ? '關閉選單' : '開啟選單'}
+              onClick={() => setIsMenuOpen((value) => !value)}
+              className="flex h-11 w-11 items-center justify-center rounded-full border border-brand-200 bg-white text-brand-800 shadow-[0_10px_24px_rgba(66,122,91,0.08)] transition-colors hover:bg-brand-50"
             >
-              {isMenuOpen ? (
-                <path 
-                  strokeLinecap="round" 
-                  strokeLinejoin="round" 
-                  strokeWidth={2} 
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              ) : (
-                <path 
-                  strokeLinecap="round" 
-                  strokeLinejoin="round" 
-                  strokeWidth={2} 
-                  d="M4 6h16M4 12h16M4 18h16"
-                />
-              )}
-            </svg>
-          </button>
+              {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+            </button>
+          </div>
         </div>
 
-        {/* 手機版選單 */}
         <nav className="md:hidden">
-          <div className={`absolute top-full left-0 right-0 bg-white border-t border-neutral-100 shadow-lg z-50 transition-all duration-300 ease-in-out ${
-            isMenuOpen 
-              ? 'opacity-100 transform translate-y-0' 
-              : 'opacity-0 transform -translate-y-4 pointer-events-none'
-          }`}>
-            <div className={`container px-6 mx-auto py-6 transition-all duration-300 ${
-              isMenuOpen ? 'opacity-100 transform translate-y-0' : 'opacity-0 transform -translate-y-2'
-            }`}>
-              {/* 主要功能區 */}
-              <div className={`space-y-1 mb-6 transition-all duration-300 delay-75 ${
-                isMenuOpen ? 'opacity-100 transform translate-y-0' : 'opacity-0 transform -translate-y-2'
-              }`}>
-                <Link href="/case-upload" onClick={() => setIsMenuOpen(false)} className="flex items-center justify-between w-full bg-brand-500 text-white px-4 py-3 rounded-xl hover:bg-brand-600 transition-colors">
-                  <span className="font-medium">找家教</span>
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </Link>
+          <div
+            className={`overflow-hidden border-t border-brand-100/70 transition-all duration-300 ${
+              isMenuOpen ? 'max-h-[32rem] opacity-100' : 'max-h-0 opacity-0'
+            }`}
+          >
+            <div className="space-y-5 px-1 py-5">
+              <div className="grid gap-3">
+                {primaryMobileLinks.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    onClick={() => setIsMenuOpen(false)}
+                    className="flex items-center justify-between rounded-[1.35rem] border border-brand-100 bg-white px-4 py-4 shadow-[0_12px_30px_rgba(66,122,91,0.06)]"
+                  >
+                    <div>
+                      <div className="text-base font-semibold text-brand-900">{link.label}</div>
+                      <div className="mt-1 text-sm text-neutral-500">{link.description}</div>
+                    </div>
+                    <ChevronRight className="h-5 w-5 text-brand-500" />
+                  </Link>
+                ))}
               </div>
-              
-              {/* 瀏覽區域 */}
-              <div className={`space-y-1 mb-6 transition-all duration-300 delay-100 ${
-                isMenuOpen ? 'opacity-100 transform translate-y-0' : 'opacity-0 transform -translate-y-2'
-              }`}>
-                <div className="text-xs font-medium text-neutral-500 uppercase tracking-wide px-2 mb-2">瀏覽</div>
-                <Link href="/tutor-cases" onClick={() => setIsMenuOpen(false)} className="flex items-center justify-between w-full text-neutral-700 hover:text-brand-700 hover:bg-brand-50 px-4 py-3 rounded-lg transition-colors">
-                  <span>案件專區</span>
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </Link>
-                <Link href="/tutors" onClick={() => setIsMenuOpen(false)} className="flex items-center justify-between w-full text-neutral-700 hover:text-brand-700 hover:bg-brand-50 px-4 py-3 rounded-lg transition-colors">
-                  <span>家教老師</span>
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </Link>
-              </div>
-              
-              {/* 工具和註冊 */}
-              <div className={`space-y-1 transition-all duration-300 delay-150 ${
-                isMenuOpen ? 'opacity-100 transform translate-y-0' : 'opacity-0 transform -translate-y-2'
-              }`}>
-                <div className="text-xs font-medium text-neutral-500 uppercase tracking-wide px-2 mb-2">服務</div>
-                <Link href="/solver" onClick={() => setIsMenuOpen(false)} className="flex items-center justify-between w-full text-neutral-700 hover:text-brand-700 hover:bg-brand-50 px-4 py-3 rounded-lg transition-colors">
-                  <span>AI解題</span>
-                  <div className="flex items-center space-x-2">
-                    <div className="w-2 h-2 bg-brand-400 rounded-full"></div>
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </div>
-                </Link>
-                <Link href="/tutor-registration" onClick={() => setIsMenuOpen(false)} className="flex items-center justify-between w-full text-neutral-700 hover:text-brand-700 hover:bg-brand-50 px-4 py-3 rounded-lg transition-colors">
-                  <span>教師登錄</span>
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </Link>
+
+              <div className="rounded-[1.35rem] border border-brand-100 bg-white px-4 py-4 shadow-[0_12px_30px_rgba(66,122,91,0.06)]">
+                <div className="mb-3 text-xs font-semibold uppercase tracking-[0.24em] text-brand-500">其他</div>
+                <div className="space-y-1">
+                  {secondaryMobileLinks.map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      onClick={() => setIsMenuOpen(false)}
+                      className="flex items-center justify-between rounded-xl px-3 py-3 text-sm font-medium text-neutral-700 transition-colors hover:bg-brand-50 hover:text-brand-700"
+                    >
+                      <span>{link.label}</span>
+                      <ChevronRight className="h-4 w-4" />
+                    </Link>
+                  ))}
+                </div>
               </div>
             </div>
           </div>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test tests/**/*.test.cjs"
   },
   "dependencies": {
     "@firebase/auth": "^1.10.6",

--- a/tests/homepage-redesign.test.cjs
+++ b/tests/homepage-redesign.test.cjs
@@ -1,0 +1,25 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const readHomepageSource = () =>
+  fs.readFileSync(path.join(process.cwd(), 'app/page.tsx'), 'utf8')
+
+test('homepage includes the new consulting-focused parent journey', () => {
+  const source = readHomepageSource()
+
+  assert.match(source, /先安心，再幫孩子找到適合的老師/)
+  assert.match(source, /#process/)
+  assert.match(source, /id="process"/)
+  assert.match(source, /想開始接家教案件？查看流程與申請條件/)
+  assert.match(source, /還沒準備找老師？先用 AI 解題看看/)
+})
+
+test('desktop hero cards use a matched-height layout', () => {
+  const source = readHomepageSource()
+
+  assert.match(source, /lg:items-stretch/)
+  assert.match(source, /lg:h-full/)
+  assert.match(source, /lg:grid-rows-\[auto_1fr\]/)
+})


### PR DESCRIPTION
### 摘要

將首頁與全站外層 layout 調整為較完整的諮詢／家長動線與視覺層次，並同步更新頁首、全域 CSS。新增以 `app/page.tsx` 原始碼為對象的 Node 測試，並在 `package.json` 補上 lint / test 相關 script，方便 CI 與本地驗證。

### 變更範圍

- **`app/page.tsx`**：首頁大篇幅重構（複製、區塊結構、諮詢向文案與 CTA；含 `#process` 等錨點與桌面版 hero 卡片等高佈局類別）。
- **`components/header.tsx`**：導覽列行為與樣式調整，與新首頁一致。
- **`app/layout.tsx`**：全站 metadata／結構或包裹方式更新（與新首頁、SEO／分享呈現對齊）。
- **`app/globals.css`**：全域樣式微調，配合新版 UI。
- **`tests/homepage-redesign.test.cjs`**：使用 Node 內建 `test`／`assert`，檢查首頁原始碼是否含關鍵中文文案、流程區塊錨點、家教申請／AI 解題等字串，以及桌面 hero 的 `lg:items-stretch`／`lg:h-full`／`lg:grid-rows-[auto_1fr]` 等 class。
- **`package.json`**：新增或調整 lint / test script（與上述測試對應）。

### 如何測試

```bash
npm run test
# 若有調整過 script 名稱，请以 package.json 為準
```

本地瀏覽：`npm run dev`（依你專案慣用 port）並手動檢查首頁、header、錨點捲動與響應式版面。

### 合併注意

- 目標分支：**`dev`**
- 建議在 merge 前確認 **`dev` 已 rebase / merge 到最新**，並跑過 lint + test。
