### PR TITLE
feat(app): replace admin case webhook with smtp notifications

### DIFF
--- a/app/api/cases/upload/route.ts
+++ b/app/api/cases/upload/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server'
 import { casesCollection } from '@/server/config/firebase'
 import { addDoc } from 'firebase/firestore'
 import { v4 as uuidv4 } from 'uuid'
+import { buildLocationSummary } from '@/lib/address-utils'
+import { notifyNewCaseAdmins } from '@/lib/notifications/admin-case-review'
 
 export async function POST(request: Request) {
   try {
@@ -9,24 +11,61 @@ export async function POST(request: Request) {
     const data = await request.json()
     console.log('Received case data:', data)
 
+    const lessonMode = data.lessonMode ?? (data.region === '線上' ? 'online' : 'in_person')
+    const locationSummary =
+      typeof data.location === 'string' && data.location.trim()
+        ? data.location.trim()
+        : buildLocationSummary({
+            city: data.city,
+            district: data.district,
+            roadName: data.roadName,
+            landmark: data.landmark,
+            lessonMode,
+            onlineDetail: data.onlineDetail,
+          })
+
+    const normalizedCaseData = {
+      ...data,
+      address:
+        locationSummary ||
+        (typeof data.address === 'string' && data.address.trim() ? data.address.trim() : undefined),
+      hourlyFee:
+        typeof data.hourlyFee === 'string' && data.hourlyFee.trim()
+          ? data.hourlyFee.trim()
+          : typeof data.budgetRange === 'string'
+            ? data.budgetRange.trim()
+            : data.hourlyFee,
+    }
+
+    if ('budgetRange' in normalizedCaseData) {
+      delete normalizedCaseData.budgetRange
+    }
+
     // 產生唯一ID
     const uniqueId = uuidv4() as string & { readonly brand: unique symbol }
+    const caseRecord = {
+      ...normalizedCaseData,
+      id: uniqueId,
+      pending: 'pending',
+      documentStatus: normalizedCaseData.documentStatus || 'not_requested',
+      createdAt: new Date().toISOString(),
+    }
 
     // 新增到 Firebase
-    const docRef = await addDoc(casesCollection, {
-      ...data,
-      id: uniqueId,
-      pending: 'pending', 
-      documentStatus: data.documentStatus || 'not_requested',
-      createdAt: new Date().toISOString(),
-    })
+    const docRef = await addDoc(casesCollection, caseRecord)
 
     console.log('Case created:', docRef)
+
+    try {
+      await notifyNewCaseAdmins(caseRecord)
+    } catch (notificationError) {
+      console.error('Error notifying admins about new case:', notificationError)
+    }
     
     const response = {
       success: true,
       id: uniqueId,
-      ...data
+      ...normalizedCaseData
     }
     console.log('Case created:', response)
 

--- a/components/case-upload-form.tsx
+++ b/components/case-upload-form.tsx
@@ -29,7 +29,6 @@ import TermsDialog from '@/components/TermsDialog'
 import { buildLocationSummary, isRoadNameValid } from '@/lib/address-utils'
 import { budgetRangeOptions, gradeOptions, schedulePresetOptions, subjectOptions } from '@/lib/case-form-options'
 import { cn } from '@/lib/utils'
-import { sendWebhookNotification } from '@/webhook-config'
 
 type SubmitStatus = 'idle' | 'success' | 'error'
 type StepKey = 'matching' | 'student' | 'contact'
@@ -569,7 +568,7 @@ export default function CaseUploadForm() {
         region: formData.lessonMode === 'online' ? onlineOption : formData.city,
         availableTime: availableTimeSummary,
         teacherRequirements: formData.teacherRequirements.trim(),
-        budgetRange: formData.budgetRange,
+        hourlyFee: formData.budgetRange,
         message: formData.message.trim(),
         status: '急徵',
         pending: 'pending',
@@ -591,7 +590,6 @@ export default function CaseUploadForm() {
       queueScrollToTop()
       setSubmitStatus('success')
       setSubmitMessage('已收到需求，我們將盡快安排家教老師與您聯繫。')
-      await sendWebhookNotification('new_case', caseData)
       resetForm()
     } catch (error) {
       console.error('送出需求失敗:', error)

--- a/lib/case-utils.ts
+++ b/lib/case-utils.ts
@@ -29,9 +29,16 @@ export const DOCUMENT_STATUS_META: Record<
   submitted: { label: '已完成', tone: 'success' },
 }
 
-export const normalizeBudgetRange = (budgetRange?: string | null, hourlyFee?: number | null) => {
+export const normalizeBudgetRange = (
+  budgetRange?: string | null,
+  hourlyFee?: string | number | null
+) => {
   if (budgetRange?.trim()) {
     return budgetRange.trim()
+  }
+
+  if (typeof hourlyFee === 'string' && hourlyFee.trim()) {
+    return hourlyFee.trim()
   }
 
   if (typeof hourlyFee === 'number' && Number.isFinite(hourlyFee)) {

--- a/lib/notifications/admin-case-review.ts
+++ b/lib/notifications/admin-case-review.ts
@@ -1,0 +1,317 @@
+import { createTransport } from 'nodemailer'
+import type { Transporter } from 'nodemailer'
+
+import { buildLocationSummary, type LessonMode } from '@/lib/address-utils'
+import { adminDb } from '@/lib/firebase/firebase-admin'
+
+type AdminDbLike = {
+  collection: (name: string) => {
+    get: () => Promise<{
+      docs: Array<{
+        data: () => {
+          email?: string | null
+        }
+      }>
+    }>
+  }
+}
+
+export interface AdminCaseReviewNotificationData {
+  caseNumber: string
+  parentName: string
+  parentPhone: string
+  parentEmail: string
+  subject: string
+  grade: string
+  region: string
+  displayAddress: string
+  displayBudget: string
+  availableTime: string
+  studentDescription: string
+  teacherRequirements: string
+  message: string
+  adminUrl: string
+}
+
+export interface AdminCaseReviewSource {
+  caseNumber?: string
+  parentName?: string
+  parentPhone?: string
+  parentEmail?: string
+  subject?: string
+  grade?: string
+  region?: string
+  lessonMode?: LessonMode
+  location?: string
+  city?: string
+  district?: string
+  roadName?: string
+  landmark?: string
+  onlineDetail?: string
+  address?: string
+  hourlyFee?: string | number
+  budgetRange?: string
+  availableTime?: string
+  studentDescription?: string
+  teacherRequirements?: string
+  message?: string
+}
+
+type BuildNotificationOptions = {
+  siteUrl?: string
+}
+
+type SendAdminCaseReviewEmailArgs = {
+  recipientEmails: string[]
+  notification: AdminCaseReviewNotificationData
+}
+
+let cachedTransporter: Transporter | null = null
+
+const smtpEnvKeys = ['SMTP_HOST', 'SMTP_PORT', 'SMTP_SECURE', 'SMTP_USER', 'SMTP_PASS', 'SMTP_FROM_EMAIL'] as const
+
+const normalizeText = (value?: string | null) => value?.trim() || ''
+
+const ensureValue = (value: string, fallback: string) => value || fallback
+
+const normalizeBool = (value?: string | null) => String(value).toLowerCase() === 'true'
+
+const normalizeSiteUrl = (siteUrl?: string | null) => siteUrl?.trim().replace(/\/+$/, '') || ''
+
+const buildAdminUrl = (siteUrl?: string | null) => {
+  const normalized = normalizeSiteUrl(siteUrl)
+  return normalized ? `${normalized}/admin` : '/admin'
+}
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+const formatOptionalText = (value: string) => value || 'N/A'
+
+const buildDisplayBudget = (caseData: AdminCaseReviewSource) => {
+  const budgetRange = normalizeText(caseData.budgetRange)
+  if (budgetRange) {
+    return budgetRange
+  }
+
+  if (typeof caseData.hourlyFee === 'string' && caseData.hourlyFee.trim()) {
+    return caseData.hourlyFee.trim()
+  }
+
+  if (typeof caseData.hourlyFee === 'number' && Number.isFinite(caseData.hourlyFee)) {
+    return `NT$${caseData.hourlyFee}/時`
+  }
+
+  return '未填預算'
+}
+
+const buildDisplayAddress = (caseData: AdminCaseReviewSource) => {
+  const location = normalizeText(caseData.location)
+  if (location) {
+    return location
+  }
+
+  const structuredLocation = buildLocationSummary({
+    city: caseData.city,
+    district: caseData.district,
+    roadName: caseData.roadName,
+    landmark: caseData.landmark,
+    lessonMode: caseData.lessonMode,
+    onlineDetail: caseData.onlineDetail,
+  })
+
+  if (structuredLocation) {
+    return structuredLocation
+  }
+
+  const legacyAddress = normalizeText(caseData.address)
+  if (legacyAddress) {
+    return legacyAddress
+  }
+
+  return '未填地址'
+}
+
+const buildRegion = (caseData: AdminCaseReviewSource) => {
+  const explicitRegion = normalizeText(caseData.region)
+  if (explicitRegion) {
+    return explicitRegion
+  }
+
+  if (caseData.lessonMode === 'online') {
+    return '線上'
+  }
+
+  return normalizeText(caseData.city) || '未填地區'
+}
+
+const getRequiredSmtpConfig = () => {
+  const missingKeys = smtpEnvKeys.filter((key) => !normalizeText(process.env[key]))
+  if (missingKeys.length > 0) {
+    throw new Error(`Missing SMTP configuration: ${missingKeys.join(', ')}`)
+  }
+
+  return {
+    host: normalizeText(process.env.SMTP_HOST),
+    port: Number.parseInt(normalizeText(process.env.SMTP_PORT), 10),
+    secure: normalizeBool(process.env.SMTP_SECURE),
+    user: normalizeText(process.env.SMTP_USER),
+    pass: normalizeText(process.env.SMTP_PASS),
+    fromEmail: normalizeText(process.env.SMTP_FROM_EMAIL),
+    fromName: normalizeText(process.env.SMTP_FROM_NAME) || normalizeText(process.env.SITE_NAME) || '青椒老師家教中心',
+  }
+}
+
+const getTransporter = () => {
+  if (cachedTransporter) {
+    return cachedTransporter
+  }
+
+  const config = getRequiredSmtpConfig()
+  cachedTransporter = createTransport({
+    host: config.host,
+    port: config.port,
+    secure: config.secure,
+    auth: {
+      user: config.user,
+      pass: config.pass,
+    },
+  })
+
+  return cachedTransporter
+}
+
+const buildAdminCaseReviewHtml = (notification: AdminCaseReviewNotificationData) => {
+  const rows = [
+    `家長姓名：${notification.parentName}`,
+    `聯絡電話：${notification.parentPhone}`,
+    `電子信箱：${formatOptionalText(notification.parentEmail)}`,
+    `聯絡地址：${notification.displayAddress}`,
+    `需求科目：${notification.subject}`,
+    `學生年級：${notification.grade}`,
+    `地區：${notification.region}`,
+    `期望預算：${notification.displayBudget}`,
+    `可上課時段：${notification.availableTime}`,
+    `案件編號：${notification.caseNumber}`,
+  ]
+
+  const details = [
+    `學生狀況：${formatOptionalText(notification.studentDescription)}`,
+    `教師要求：${formatOptionalText(notification.teacherRequirements)}`,
+    `補充說明：${formatOptionalText(notification.message)}`,
+  ]
+
+  return `
+    <div style="background:#171717;padding:24px;color:#f5f5f5;font-family:'Segoe UI',sans-serif;line-height:1.7;">
+      <h1 style="margin:0 0 20px;color:#5b8cff;">新案件通知</h1>
+      <div style="background:#3a3a3a;border-radius:16px;padding:24px;">
+        <h2 style="margin:0 0 16px;font-size:28px;">案件資訊</h2>
+        ${rows.map((row) => `<p style="margin:0 0 12px;font-size:18px;">${escapeHtml(row)}</p>`).join('')}
+      </div>
+      <div style="background:#6f6730;border-radius:16px;padding:24px;margin-top:24px;">
+        ${details.map((row) => `<p style="margin:0 0 12px;font-size:18px;">${escapeHtml(row)}</p>`).join('')}
+      </div>
+      <p style="margin:24px 0 0;font-size:18px;">
+        <a href="${escapeHtml(notification.adminUrl)}" style="color:#5b8cff;">請登入後台審核此案件。</a>
+      </p>
+    </div>
+  `.trim()
+}
+
+const buildAdminCaseReviewText = (notification: AdminCaseReviewNotificationData) => [
+  '新案件通知',
+  '',
+  '案件資訊',
+  `家長姓名：${notification.parentName}`,
+  `聯絡電話：${notification.parentPhone}`,
+  `電子信箱：${formatOptionalText(notification.parentEmail)}`,
+  `聯絡地址：${notification.displayAddress}`,
+  `需求科目：${notification.subject}`,
+  `學生年級：${notification.grade}`,
+  `地區：${notification.region}`,
+  `期望預算：${notification.displayBudget}`,
+  `可上課時段：${notification.availableTime}`,
+  `案件編號：${notification.caseNumber}`,
+  '',
+  `學生狀況：${formatOptionalText(notification.studentDescription)}`,
+  `教師要求：${formatOptionalText(notification.teacherRequirements)}`,
+  `補充說明：${formatOptionalText(notification.message)}`,
+  '',
+  `請登入後台審核此案件：${notification.adminUrl}`,
+].join('\n')
+
+export const buildAdminCaseReviewNotificationData = (
+  caseData: AdminCaseReviewSource,
+  options: BuildNotificationOptions = {}
+): AdminCaseReviewNotificationData => ({
+  caseNumber: ensureValue(normalizeText(caseData.caseNumber), '未填案件編號'),
+  parentName: ensureValue(normalizeText(caseData.parentName), '未填家長姓名'),
+  parentPhone: ensureValue(normalizeText(caseData.parentPhone), '未填聯絡電話'),
+  parentEmail: normalizeText(caseData.parentEmail),
+  subject: ensureValue(normalizeText(caseData.subject), '未填需求科目'),
+  grade: ensureValue(normalizeText(caseData.grade), '未填學生年級'),
+  region: buildRegion(caseData),
+  displayAddress: buildDisplayAddress(caseData),
+  displayBudget: buildDisplayBudget(caseData),
+  availableTime: ensureValue(normalizeText(caseData.availableTime), '未填可上課時段'),
+  studentDescription: normalizeText(caseData.studentDescription),
+  teacherRequirements: normalizeText(caseData.teacherRequirements),
+  message: normalizeText(caseData.message),
+  adminUrl: buildAdminUrl(options.siteUrl ?? process.env.SITE_URL),
+})
+
+export const loadAdminRecipientEmails = async (db: AdminDbLike = adminDb as AdminDbLike) => {
+  const snapshot = await db.collection('admins').get()
+  const uniqueEmails = new Set<string>()
+
+  snapshot.docs.forEach((doc) => {
+    const email = normalizeText(doc.data().email).toLowerCase()
+    if (email && email.includes('@')) {
+      uniqueEmails.add(email)
+    }
+  })
+
+  return [...uniqueEmails]
+}
+
+export const sendAdminCaseReviewEmail = async ({
+  recipientEmails,
+  notification,
+}: SendAdminCaseReviewEmailArgs) => {
+  if (recipientEmails.length === 0) {
+    console.log('No admin recipients configured for new case review email.')
+    return { skipped: true }
+  }
+
+  const transporter = getTransporter()
+  const { fromEmail, fromName } = getRequiredSmtpConfig()
+  const subject = `新案件通知 - ${notification.subject}`
+
+  const result = await transporter.sendMail({
+    from: `${fromName} <${fromEmail}>`,
+    to: recipientEmails.join(', '),
+    subject,
+    html: buildAdminCaseReviewHtml(notification),
+    text: buildAdminCaseReviewText(notification),
+  })
+
+  return { skipped: false, messageId: result.messageId ?? null }
+}
+
+export const notifyNewCaseAdmins = async (
+  caseData: AdminCaseReviewSource,
+  options: BuildNotificationOptions = {}
+) => {
+  const recipientEmails = await loadAdminRecipientEmails()
+  const notification = buildAdminCaseReviewNotificationData(caseData, options)
+
+  return sendAdminCaseReviewEmail({
+    recipientEmails,
+    notification,
+  })
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -49,7 +49,7 @@ export interface TutorCase {
     region: string;
     availableTime: string;
     teacherRequirements?: string;
-    hourlyFee?: number;
+    hourlyFee?: number | string;
     budgetRange?: string;
     message?: string;
     status: '急徵' | '已徵到' | '有人接洽';
@@ -72,7 +72,7 @@ export interface ApprovedCase {
     availableTime: string;
     studentDescription: string;
     teacherRequirements?: string;
-    hourlyFee?: number;
+    hourlyFee?: number | string;
     budgetRange?: string;
     status: '急徵' | '已徵到' | '有人接洽';
     approvedAt: string;

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -53,7 +53,7 @@ export interface TutorCase {
     region: string;
     availableTime: string;
     teacherRequirements?: string;
-    hourlyFee?: number;
+    hourlyFee?: number | string;
     budgetRange?: string;
     message?: string;
     status: '急徵' | '已徵到' | '有人接洽';
@@ -76,7 +76,7 @@ export interface ApprovedCase {
     availableTime: string;
     studentDescription: string;
     teacherRequirements?: string;
-    hourlyFee?: number;
+    hourlyFee?: number | string;
     budgetRange?: string;
     status: '急徵' | '已徵到' | '有人接洽';
     approvedAt: string;
@@ -118,7 +118,7 @@ export interface ChatHistory {
 export interface CaseNotificationData {
   caseNumber: string;
   subject: string;
-  hourlyFee?: number;
+  hourlyFee?: number | string;
   budgetRange?: string;
   location: string;
   availableTime: string;

--- a/tests/admin-case-review-notification.test.cjs
+++ b/tests/admin-case-review-notification.test.cjs
@@ -1,0 +1,351 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+const ts = require('typescript')
+
+const projectRoot = process.cwd()
+
+const readSource = (relativePath) =>
+  fs.readFileSync(path.join(projectRoot, relativePath), 'utf8')
+
+const loadTsModule = (relativePath, mocks = {}) => {
+  const filePath = path.join(projectRoot, relativePath)
+  const source = fs.readFileSync(filePath, 'utf8')
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+    fileName: filePath,
+  }).outputText
+
+  const module = { exports: {} }
+  const dirname = path.dirname(filePath)
+
+  const localRequire = (request) => {
+    if (request in mocks) {
+      return mocks[request]
+    }
+
+    if (request === 'server-only') {
+      return {}
+    }
+
+    if (request.startsWith('.')) {
+      return require(path.resolve(dirname, request))
+    }
+
+    return require(request)
+  }
+
+  const wrapped = `(function (exports, require, module, __filename, __dirname) { ${transpiled}\n})`
+  const script = new vm.Script(wrapped, { filename: filePath })
+  const fn = script.runInThisContext()
+  fn(module.exports, localRequire, module, filePath, dirname)
+  return module.exports
+}
+
+test('case upload form no longer sends new-case admin webhooks from the client', () => {
+  const source = readSource('components/case-upload-form.tsx')
+
+  assert.doesNotMatch(source, /sendWebhookNotification/)
+  assert.doesNotMatch(source, /webhook-config/)
+})
+
+test('webhook config no longer routes new_case notifications through webhook config', () => {
+  const source = readSource('webhook-config.ts')
+
+  assert.doesNotMatch(source, /'new_case'/)
+})
+
+test('admin case review notification builder uses redesigned budget and address fields', async () => {
+  const modulePath = path.join(projectRoot, 'lib/notifications/admin-case-review.ts')
+  assert.ok(fs.existsSync(modulePath), 'expected admin case review notification module to exist')
+
+  const { buildAdminCaseReviewNotificationData } = loadTsModule('lib/notifications/admin-case-review.ts', {
+    nodemailer: { createTransport: () => ({ sendMail: async () => ({}) }) },
+    '@/lib/address-utils': {
+      buildLocationSummary: () => '不應該使用備援地址摘要',
+    },
+    '@/lib/firebase/firebase-admin': {
+      adminDb: {},
+    },
+  })
+
+  const data = buildAdminCaseReviewNotificationData(
+    {
+      caseNumber: 'CS2WI6O',
+      parentName: '吳珈穆',
+      parentPhone: '0918837352',
+      parentEmail: '',
+      subject: '國中國文',
+      grade: '國二',
+      region: '新竹市',
+      location: '新竹市東區光復路，近清大',
+      budgetRange: 'NT$500-700 / 時',
+      availableTime: '平日晚上',
+      studentDescription: '校內功課+會考',
+      teacherRequirements: '有帶國中會考經驗',
+      message: '',
+    },
+    { siteUrl: 'https://tutor-matching.tw' }
+  )
+
+  assert.equal(data.displayBudget, 'NT$500-700 / 時')
+  assert.equal(data.displayAddress, '新竹市東區光復路，近清大')
+  assert.equal(data.adminUrl, 'https://tutor-matching.tw/admin')
+})
+
+test('admin case review notification builder falls back to hourly fee and legacy address', async () => {
+  const { buildAdminCaseReviewNotificationData } = loadTsModule('lib/notifications/admin-case-review.ts', {
+    nodemailer: { createTransport: () => ({ sendMail: async () => ({}) }) },
+    '@/lib/address-utils': {
+      buildLocationSummary: () => '',
+    },
+    '@/lib/firebase/firebase-admin': {
+      adminDb: {},
+    },
+  })
+
+  const data = buildAdminCaseReviewNotificationData(
+    {
+      caseNumber: 'CLEGACY1',
+      parentName: '王小明',
+      parentPhone: '0912000000',
+      subject: '高中英文',
+      grade: '高一',
+      region: '臺北市',
+      address: '臺北市大安區和平東路二段',
+      hourlyFee: 900,
+      availableTime: '週六下午',
+      studentDescription: '段考加強',
+      teacherRequirements: '',
+      message: '請先電話聯絡',
+    },
+    { siteUrl: 'https://tutor-matching.tw/' }
+  )
+
+  assert.equal(data.displayBudget, 'NT$900/時')
+  assert.equal(data.displayAddress, '臺北市大安區和平東路二段')
+  assert.equal(data.adminUrl, 'https://tutor-matching.tw/admin')
+})
+
+test('admin recipient loader normalizes, deduplicates, and skips missing emails', async () => {
+  const { loadAdminRecipientEmails } = loadTsModule('lib/notifications/admin-case-review.ts', {
+    nodemailer: { createTransport: () => ({ sendMail: async () => ({}) }) },
+    '@/lib/address-utils': {
+      buildLocationSummary: () => '',
+    },
+    '@/lib/firebase/firebase-admin': {
+      adminDb: {
+        collection: () => ({
+          get: async () => ({
+            docs: [
+              { data: () => ({ email: 'Admin@One.com ' }) },
+              { data: () => ({ email: 'admin@one.com' }) },
+              { data: () => ({ email: 'ops@two.com' }) },
+              { data: () => ({ email: '' }) },
+              { data: () => ({}) },
+            ],
+          }),
+        }),
+      },
+    },
+  })
+
+  const emails = await loadAdminRecipientEmails()
+
+  assert.deepEqual(emails, ['admin@one.com', 'ops@two.com'])
+})
+
+test('case normalization accepts string hourlyFee for new cases and numeric hourlyFee for legacy cases', async () => {
+  const { normalizeBudgetRange } = loadTsModule('lib/case-utils.ts', {
+    '@/lib/address-utils': {
+      buildLocationSummary: () => '',
+    },
+  })
+
+  assert.equal(normalizeBudgetRange(undefined, 'NT$500-700 / 時'), 'NT$500-700 / 時')
+  assert.equal(normalizeBudgetRange(undefined, 900), 'NT$900/時')
+})
+
+test('admin mailer sends normalized fields and admin link via SMTP transport', async () => {
+  const originalEnv = { ...process.env }
+  let sentMessage = null
+
+  process.env.SMTP_HOST = 'smtp.example.com'
+  process.env.SMTP_PORT = '465'
+  process.env.SMTP_SECURE = 'true'
+  process.env.SMTP_USER = 'mailer@example.com'
+  process.env.SMTP_PASS = 'secret'
+  process.env.SMTP_FROM_EMAIL = 'contact@tutor-matching.tw'
+  process.env.SMTP_FROM_NAME = '青椒老師家教中心'
+
+  try {
+    const { sendAdminCaseReviewEmail } = loadTsModule('lib/notifications/admin-case-review.ts', {
+      nodemailer: {
+        createTransport: () => ({
+          sendMail: async (options) => {
+            sentMessage = options
+            return { messageId: 'msg-1' }
+          },
+        }),
+      },
+      '@/lib/address-utils': {
+        buildLocationSummary: () => '',
+      },
+      '@/lib/firebase/firebase-admin': {
+        adminDb: {},
+      },
+    })
+
+    await sendAdminCaseReviewEmail({
+      recipientEmails: ['admin@one.com'],
+      notification: {
+        caseNumber: 'CS2WI6O',
+        parentName: '吳珈穆',
+        parentPhone: '0918837352',
+        parentEmail: '',
+        subject: '國中國文',
+        grade: '國二',
+        region: '新竹市',
+        displayAddress: '新竹市東區光復路，近清大',
+        displayBudget: 'NT$500-700 / 時',
+        availableTime: '平日晚上',
+        studentDescription: '校內功課+會考',
+        teacherRequirements: '有帶國中會考經驗',
+        message: '',
+        adminUrl: 'https://tutor-matching.tw/admin',
+      },
+    })
+
+    assert.ok(sentMessage, 'expected sendMail to be called')
+    assert.equal(sentMessage.subject, '新案件通知 - 國中國文')
+    assert.equal(sentMessage.to, 'admin@one.com')
+    assert.match(sentMessage.html, /聯絡地址：新竹市東區光復路，近清大/)
+    assert.match(sentMessage.html, /期望預算：NT\$500-700 \/ 時/)
+    assert.match(sentMessage.html, /https:\/\/tutor-matching\.tw\/admin/)
+    assert.match(sentMessage.text, /補充說明：N\/A/)
+  } finally {
+    Object.keys(process.env).forEach((key) => {
+      if (!(key in originalEnv)) {
+        delete process.env[key]
+      }
+    })
+    Object.assign(process.env, originalEnv)
+  }
+})
+
+test('case upload route still returns success when admin notification sending fails', async () => {
+  let savedPayload = null
+  let notifiedPayload = null
+
+  const { POST } = loadTsModule('app/api/cases/upload/route.ts', {
+    'next/server': {
+      NextResponse: class NextResponse extends Response {},
+    },
+    '@/server/config/firebase': {
+      casesCollection: { id: 'cases' },
+    },
+    'firebase/firestore': {
+      addDoc: async (_collection, payload) => {
+        savedPayload = payload
+        return { id: 'doc-1' }
+      },
+    },
+    uuid: {
+      v4: () => 'uuid-1',
+    },
+    '@/lib/address-utils': {
+      buildLocationSummary: () => '不應該使用結構化地址備援',
+    },
+    '@/lib/notifications/admin-case-review': {
+      notifyNewCaseAdmins: async (payload) => {
+        notifiedPayload = payload
+        throw new Error('SMTP unavailable')
+      },
+    },
+  })
+
+  const response = await POST({
+    json: async () => ({
+      caseNumber: 'CS2WI6O',
+      parentName: '吳珈穆',
+      parentPhone: '0918837352',
+      subject: '國中國文',
+      grade: '國二',
+      location: '新竹市東區光復路，近清大',
+      budgetRange: 'NT$500-700 / 時',
+      availableTime: '平日晚上',
+      studentDescription: '校內功課+會考',
+      teacherRequirements: '有帶國中會考經驗',
+    }),
+  })
+
+  const result = JSON.parse(await response.text())
+
+  assert.equal(response.status, 201)
+  assert.equal(result.success, true)
+  assert.equal(savedPayload.id, 'uuid-1')
+  assert.equal(savedPayload.pending, 'pending')
+  assert.equal(savedPayload.documentStatus, 'not_requested')
+  assert.equal(savedPayload.hourlyFee, 'NT$500-700 / 時')
+  assert.equal(savedPayload.address, '新竹市東區光復路，近清大')
+  assert.equal(Object.hasOwn(savedPayload, 'budgetRange'), false)
+  assert.equal(notifiedPayload.id, 'uuid-1')
+  assert.equal(notifiedPayload.hourlyFee, 'NT$500-700 / 時')
+  assert.equal(notifiedPayload.address, '新竹市東區光復路，近清大')
+})
+
+test('case upload route rebuilds legacy address from structured address fields when location is missing', async () => {
+  let savedPayload = null
+
+  const { POST } = loadTsModule('app/api/cases/upload/route.ts', {
+    'next/server': {
+      NextResponse: class NextResponse extends Response {},
+    },
+    '@/server/config/firebase': {
+      casesCollection: { id: 'cases' },
+    },
+    'firebase/firestore': {
+      addDoc: async (_collection, payload) => {
+        savedPayload = payload
+        return { id: 'doc-2' }
+      },
+    },
+    uuid: {
+      v4: () => 'uuid-2',
+    },
+    '@/lib/address-utils': {
+      buildLocationSummary: ({ city, district, roadName, landmark }) =>
+        `${city}${district}${roadName}，近${landmark}`,
+    },
+    '@/lib/notifications/admin-case-review': {
+      notifyNewCaseAdmins: async () => {},
+    },
+  })
+
+  const response = await POST({
+    json: async () => ({
+      caseNumber: 'CSTRUCT1',
+      parentName: '測試家長',
+      parentPhone: '0912000000',
+      subject: '高中英文',
+      city: '臺北市',
+      district: '大安區',
+      roadName: '和平東路二段',
+      landmark: '古亭站',
+      lessonMode: 'in_person',
+      hourlyFee: 'NT$800-1000 / 時',
+    }),
+  })
+
+  const result = JSON.parse(await response.text())
+
+  assert.equal(response.status, 201)
+  assert.equal(result.success, true)
+  assert.equal(savedPayload.address, '臺北市大安區和平東路二段，近古亭站')
+})

--- a/webhook-config.ts
+++ b/webhook-config.ts
@@ -1,16 +1,13 @@
 // webhook-config.ts
-// n8n Webhook 配置
+// 教師申請與教師案件通知 webhook 配置
 
 import { CaseNotificationData } from '@/server/types'
 
 export const WEBHOOK_CONFIG = {
-  // n8n 基礎 URL - 請根據您的 n8n 實例修改
-  N8N_BASE_URL: process.env.NEXT_PUBLIC_N8N_WEBHOOK_BASE_URL || 'https://n8n.srv919029.hstgr.cloud',
-  
-  // 管理員通知 webhook 端點
+  // 管理員通知 webhook 端點（保留給教師申請流程）
   ADMIN_NOTIFICATION_WEBHOOK: process.env.NEXT_PUBLIC_ADMIN_NOTIFICATION_WEBHOOK_URL || 'https://n8n.srv919029.hstgr.cloud/webhook/admin-notifications',
 
-  // 新家教案件郵件通知 webhook 端點
+  // 新家教案件郵件通知 webhook 端點（發送給已核准教師）
   NEW_CASE_EMAIL_WEBHOOK: process.env.NEXT_PUBLIC_NEW_CASE_EMAIL_WEBHOOK_URL || 'https://n8n.srv919029.hstgr.cloud/webhook/new-tutor-case',
   
   // webhook 請求超時時間（毫秒）- 增加到 15 秒
@@ -31,21 +28,19 @@ console.log('ENABLE_WEBHOOKS config:', WEBHOOK_CONFIG.ENABLE_WEBHOOKS)
 // 延遲函數
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-// webhook 發送函數
-export const sendWebhookNotification = async (type: 'new_case' | 'new_tutor', data: any) => {
-  // 如果 webhook 功能未啟用，直接返回
+// webhook 發送函數（目前僅保留給教師申請流程）
+export const sendWebhookNotification = async (type: 'new_tutor', data: any) => {
   if (!WEBHOOK_CONFIG.ENABLE_WEBHOOKS) {
     console.log('Webhook 功能未啟用，跳過通知發送')
     return
   }
 
   let lastError: Error | null = null;
-  
-  // 重試機制
+
   for (let attempt = 1; attempt <= WEBHOOK_CONFIG.MAX_RETRIES; attempt++) {
     try {
-      console.log(`嘗試發送 webhook 通知 (第 ${attempt} 次嘗試)`)
-      
+      console.log(`嘗試發送 ${type} webhook 通知 (第 ${attempt} 次嘗試)`)
+
       const response = await fetch(WEBHOOK_CONFIG.ADMIN_NOTIFICATION_WEBHOOK || '', {
         method: 'POST',
         headers: {
@@ -66,23 +61,19 @@ export const sendWebhookNotification = async (type: 'new_case' | 'new_tutor', da
       const result = await response.json()
       console.log('管理員通知已發送:', result)
       return result
-      
     } catch (error) {
-      lastError = error as Error;
-      console.error(`發送管理員通知失敗 (第 ${attempt} 次嘗試):`, error)
-      
+      lastError = error as Error
+      console.error(`發送 ${type} 管理員通知失敗 (第 ${attempt} 次嘗試):`, error)
+
       if (attempt < WEBHOOK_CONFIG.MAX_RETRIES) {
-        // 計算延遲時間（使用指數退避）
-        const delayTime = Math.min(1000 * Math.pow(2, attempt - 1), 5000);
+        const delayTime = Math.min(1000 * Math.pow(2, attempt - 1), 5000)
         console.log(`等待 ${delayTime}ms 後重試...`)
         await delay(delayTime)
       }
     }
   }
 
-  // 所有重試都失敗了
-  console.error(`在 ${WEBHOOK_CONFIG.MAX_RETRIES} 次嘗試後仍無法發送通知:`, lastError)
-  // 不拋出錯誤，避免影響主要業務流程
+  console.error(`在 ${WEBHOOK_CONFIG.MAX_RETRIES} 次嘗試後仍無法發送 ${type} 通知:`, lastError)
   return null
 }
 


### PR DESCRIPTION
## Summary
- replace the new-case admin webhook with a server-side SMTP notification flow
- store budget ranges in `hourlyFee` and backfill legacy `address` from `location` or structured address fields
- add regression tests for admin recipients, SMTP email content, and upload-route normalization/failure tolerance

## Testing
- npm test
- npm run build