### PR TITLE
feat(admin): IG Story 圖片 & Dcard 貼文一鍵生成

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -7,6 +7,8 @@ import { addDoc, collection, deleteDoc, doc, getDoc, getDocs, query, updateDoc, 
 import { deleteObject, ref } from 'firebase/storage'
 import {
   Copy,
+  FileText,
+  Instagram,
   LayoutDashboard,
   Link2,
   Loader2,
@@ -34,6 +36,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import { buildCaseNotificationData, normalizeCase, type CaseDocumentStatus } from '@/lib/case-utils'
+import { generateDcardPostText } from '@/lib/dcard-post-generator'
+import { generateIgStoryImage } from '@/lib/ig-story-generator'
 import { TUTOR_REVISION_REASON_OPTIONS, type TutorRevisionReasonCode } from '@/lib/tutor-review'
 import { auth, db, storage } from '@/server/config/firebase'
 import type { CaseNotificationData, Tutor, TutorCase } from '@/server/types'
@@ -121,6 +125,10 @@ export default function AdminPage() {
   const [revisionDialogTutor, setRevisionDialogTutor] = useState<PendingTutor | null>(null)
   const [selectedRevisionReasons, setSelectedRevisionReasons] = useState<TutorRevisionReasonCode[]>([])
   const [revisionNote, setRevisionNote] = useState('')
+  // Dcard 貼文預覽/編輯 Dialog
+  const [dcardDialogOpen, setDcardDialogOpen] = useState(false)
+  const [dcardTitle, setDcardTitle] = useState('')
+  const [dcardBody, setDcardBody] = useState('')
 
   const followUpCount = useMemo(
     () => pendingCases.filter((caseItem) => normalizeCase(caseItem).documentStatus !== 'submitted').length,
@@ -270,6 +278,61 @@ export default function AdminPage() {
       setGeneratingLinkId(null)
     }
   }
+
+  // ── 行銷工具：IG Story 圖片生成 ──
+  const handleGenerateIgStory = async (caseData: PendingCase) => {
+    try {
+      const normalized = normalizeCase(caseData)
+      const blob = await generateIgStoryImage({
+        subject: normalized.subject || '',
+        budgetRange: normalized.budgetRange,
+        location: normalized.location || '',
+        availableTime: normalized.availableTime || '',
+        studentDescription: normalized.studentDescription || '',
+        teacherRequirements: normalized.teacherRequirements || '',
+      })
+      // 💡 同時下載 + 開新分頁預覽，方便管理員直接使用
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `IG-Story-${caseData.caseNumber}.png`
+      link.click()
+      window.open(url, '_blank')
+      toast.success('IG Story 圖片已產生並下載')
+    } catch (error) {
+      console.error('IG Story generation failed:', error)
+      toast.error('IG Story 圖片產生失敗')
+    }
+  }
+
+  // ── 行銷工具：Dcard 貼文預覽 ──
+  const handleGenerateDcardPost = (caseData: PendingCase) => {
+    const normalized = normalizeCase(caseData)
+    const { title, body } = generateDcardPostText({
+      subject: normalized.subject || '',
+      budgetRange: normalized.budgetRange,
+      location: normalized.location || '',
+      availableTime: normalized.availableTime || '',
+      studentDescription: normalized.studentDescription || '',
+      teacherRequirements: normalized.teacherRequirements || '',
+      grade: caseData.grade || '',
+      studentGender: caseData.studentGender || '',
+      department: caseData.department || '',
+    })
+    setDcardTitle(title)
+    setDcardBody(body)
+    setDcardDialogOpen(true)
+  }
+
+  const handleCopyDcardPost = async () => {
+    try {
+      await navigator.clipboard.writeText(`${dcardTitle}\n\n${dcardBody}`)
+      toast.success('已複製 Dcard 貼文內容到剪貼簿')
+    } catch {
+      toast.error('複製失敗，請手動選取複製')
+    }
+  }
+
 
   const handleCaseStatusUpdate = async (caseDocId: string, newStatus: '急徵' | '已徵到' | '有人接洽') => {
     if (updatingStatus) return
@@ -841,6 +904,20 @@ export default function AdminPage() {
                             </Button>
                           </div>
                         </div>
+
+                        <div className="rounded-[1.5rem] border border-brand-100 bg-white p-5 shadow-[0_14px_40px_rgba(67,102,78,0.06)]">
+                          <div className="text-sm font-semibold tracking-[0.22em] text-brand-500">行銷工具</div>
+                          <div className="mt-4 flex flex-col gap-2">
+                            <Button type="button" variant="outline" size="sm" className="rounded-full border-brand-300 bg-white text-brand-800 hover:bg-brand-50" onClick={() => handleGenerateIgStory(searchResults.case!)}>
+                              <Instagram className="h-4 w-4" />
+                              產生 IG Story 圖片
+                            </Button>
+                            <Button type="button" variant="outline" size="sm" className="rounded-full border-brand-300 bg-white text-brand-800 hover:bg-brand-50" onClick={() => handleGenerateDcardPost(searchResults.case!)}>
+                              <FileText className="h-4 w-4" />
+                              複製 Dcard 貼文
+                            </Button>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </DashboardSection>
@@ -904,6 +981,47 @@ export default function AdminPage() {
             >
               {processing ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
               寄送退回補件通知
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Dcard 貼文預覽 / 編輯 Dialog */}
+      <Dialog open={dcardDialogOpen} onOpenChange={setDcardDialogOpen}>
+        <DialogContent className="max-w-2xl rounded-[2rem] border border-brand-100 bg-[#fffdf8] p-0">
+          <DialogHeader className="border-b border-brand-100 px-6 py-5">
+            <DialogTitle className="font-display text-2xl text-brand-900">Dcard 貼文預覽</DialogTitle>
+            <DialogDescription className="mt-2 text-sm leading-7 text-neutral-600">
+              你可以直接編輯標題與內文，修改完畢後點「複製全部」。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 px-6 py-5">
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-brand-900">標題</label>
+              <Input
+                value={dcardTitle}
+                onChange={(e) => setDcardTitle(e.target.value)}
+                className="rounded-[1.25rem] border-brand-200 bg-white font-semibold"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-brand-900">內文</label>
+              <Textarea
+                value={dcardBody}
+                onChange={(e) => setDcardBody(e.target.value)}
+                className="min-h-[360px] rounded-[1.25rem] border-brand-200 bg-white leading-7"
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="border-t border-brand-100 px-6 py-5">
+            <Button type="button" variant="outline" className="rounded-full border-brand-300 bg-white text-brand-800 hover:bg-brand-50" onClick={() => setDcardDialogOpen(false)}>
+              關閉
+            </Button>
+            <Button type="button" className="rounded-full bg-brand-500 text-white hover:bg-brand-600" onClick={handleCopyDcardPost}>
+              <Copy className="h-4 w-4" />
+              複製全部
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/lib/dcard-post-generator.ts
+++ b/lib/dcard-post-generator.ts
@@ -1,0 +1,64 @@
+/**
+ * Dcard 貼文文字生成器
+ *
+ * 從案件資料自動組裝出 Dcard 發文格式的標題與內文。
+ * 產出的文字可直接複製貼上到 Dcard 發文區。
+ */
+
+interface DcardPostInput {
+  subject: string
+  budgetRange: string
+  location: string
+  availableTime: string
+  studentDescription: string
+  teacherRequirements: string
+  grade: string
+  studentGender: string
+  department: string
+}
+
+/**
+ * 從完整地址字串擷取前段（城市+區域）作為標題用的短地名。
+ * 例如 "新竹市東區光復路，近清大" → "新竹市東區"
+ */
+// 💡 中文地址常見結構：{城市}{區/鎮/鄉}{路名}，用「區/鎮/鄉/市」結尾來截斷
+function extractShortLocation(location: string): string {
+  const match = location.match(/^(.+?[區鎮鄉市])/)
+  return match ? match[1] : location.slice(0, 6)
+}
+
+// 💡 資料庫存英文 "male"/"female"，顯示時轉成中文
+const GENDER_MAP: Record<string, string> = {
+  male: '男',
+  female: '女',
+}
+
+export function generateDcardPostText(data: DcardPostInput): {
+  title: string
+  body: string
+} {
+  const shortLocation = extractShortLocation(data.location)
+  const genderLabel = GENDER_MAP[data.studentGender] ?? data.studentGender
+
+  const title = `【徵${data.subject}家教｜${shortLocation}｜${data.grade}${genderLabel}｜時薪${data.budgetRange}】`
+
+  const body = [
+    `上課地點：${data.location}`,
+    `學生性別與年齡：${data.grade}${genderLabel}`,
+    `就讀學校：${data.department || '未填寫'}`,
+    `年級：${data.grade}`,
+    `上課時段：${data.availableTime}`,
+    `時薪：${data.budgetRange}`,
+    '',
+    '【學生目前程度】',
+    data.studentDescription || '未填寫',
+    '',
+    '【教師條件】',
+    data.teacherRequirements || '無特殊要求',
+    '',
+    '──────',
+    '有興趣的同學歡迎直接私訊我！',
+  ].join('\n')
+
+  return { title, body }
+}

--- a/lib/ig-story-generator.ts
+++ b/lib/ig-story-generator.ts
@@ -1,0 +1,214 @@
+/**
+ * IG Story 圖片生成器
+ *
+ * 用 Canvas API 繪製 1080×1920 的 Instagram Story 圖片。
+ * 背景為品牌綠色漸層，內容包含案件資訊與青椒老師 Logo。
+ *
+ * 💡 使用 Canvas API 而非 html-to-image 的原因：
+ *    - 不需安裝新套件
+ *    - 像素級控制，確保 IG Story 尺寸精準
+ *    - 瀏覽器原生支援中文字體渲染
+ */
+
+const CANVAS_WIDTH = 1080
+const CANVAS_HEIGHT = 1920
+
+// 品牌色（來自 tailwind.config.js）
+const BRAND_800 = '#1f3a2d'
+const BRAND_700 = '#2d5240'
+const BRAND_500 = '#427A5B'
+const BRAND_400 = '#82b061'
+
+interface IgStoryInput {
+  subject: string
+  budgetRange: string
+  location: string
+  availableTime: string
+  studentDescription: string
+  teacherRequirements: string
+}
+
+/**
+ * 中文自動換行 helper
+ *
+ * ⚠️ 中文沒有空格分詞，不能用英文的「按空格斷詞」邏輯。
+ *    這裡逐字元量測寬度，超過 maxWidth 就換行。
+ *
+ * @returns 繪製完畢後的 y 座標（供後續欄位接續使用）
+ */
+function wrapText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  lineHeight: number,
+  maxLines = Infinity,
+): number {
+  let currentLine = ''
+  let lineCount = 0
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]
+
+    // 遇到換行符直接斷行
+    if (char === '\n') {
+      ctx.fillText(currentLine, x, y)
+      y += lineHeight
+      lineCount++
+      currentLine = ''
+      if (lineCount >= maxLines) {
+        // 在最後一行末尾加上省略號
+        break
+      }
+      continue
+    }
+
+    const testLine = currentLine + char
+    const metrics = ctx.measureText(testLine)
+
+    if (metrics.width > maxWidth && currentLine.length > 0) {
+      // 如果已經到達行數上限，加省略號然後停止
+      if (lineCount >= maxLines - 1) {
+        ctx.fillText(currentLine + '⋯', x, y)
+        y += lineHeight
+        return y
+      }
+      ctx.fillText(currentLine, x, y)
+      y += lineHeight
+      lineCount++
+      currentLine = char
+    } else {
+      currentLine = testLine
+    }
+  }
+
+  // 繪製最後一行
+  if (currentLine) {
+    ctx.fillText(currentLine, x, y)
+    y += lineHeight
+  }
+
+  return y
+}
+
+/** 載入圖片為 HTMLImageElement（Promise 包裝） */
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new window.Image()
+    img.crossOrigin = 'anonymous'
+    img.onload = () => resolve(img)
+    img.onerror = reject
+    img.src = src
+  })
+}
+
+export async function generateIgStoryImage(
+  data: IgStoryInput,
+): Promise<Blob> {
+  const canvas = document.createElement('canvas')
+  canvas.width = CANVAS_WIDTH
+  canvas.height = CANVAS_HEIGHT
+  const ctx = canvas.getContext('2d')!
+
+  // ── 1. 綠色漸層背景 ──
+  // 💡 從深到淺的四段漸層，模擬原始 IG Story 的質感
+  const gradient = ctx.createLinearGradient(0, 0, 0, CANVAS_HEIGHT)
+  gradient.addColorStop(0, BRAND_800)
+  gradient.addColorStop(0.3, BRAND_700)
+  gradient.addColorStop(0.7, BRAND_500)
+  gradient.addColorStop(1, BRAND_400)
+  ctx.fillStyle = gradient
+  ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
+
+  // ── 2. 半透明紋理疊加（增加質感） ──
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.03)'
+  for (let i = 0; i < 5; i++) {
+    ctx.fillRect(0, i * 384, CANVAS_WIDTH, 2)
+  }
+
+  const marginX = 80
+  const contentWidth = CANVAS_WIDTH - marginX * 2
+
+  // ── 3. 標題 "NEW CASE" ──
+  ctx.fillStyle = '#ffffff'
+  ctx.font = 'bold 72px "Helvetica Neue", "PingFang TC", sans-serif'
+  ctx.fillText('NEW CASE', marginX, 200)
+
+  // 標題底線裝飾
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.3)'
+  ctx.fillRect(marginX, 220, 200, 3)
+
+  // ── 4. 案件資訊欄位 ──
+  const fields = [
+    { label: '科目', value: data.subject },
+    { label: '時薪', value: data.budgetRange },
+    { label: '上課地點', value: data.location },
+    { label: '上課時間', value: data.availableTime },
+    { label: '學生描述', value: data.studentDescription },
+    { label: '教師條件', value: data.teacherRequirements },
+  ]
+
+  let currentY = 320
+  const labelFont = 'bold 40px "PingFang TC", "Noto Sans TC", sans-serif'
+  const lineHeight = 56
+
+  for (const field of fields) {
+    if (!field.value) continue
+
+    // ⚠️ 防止內容太長導致文字溢出到 footer 區域
+    // 每個欄位最多 4 行，學生描述最多 5 行
+    const maxLines = field.label === '學生描述' ? 5 : 4
+
+    ctx.fillStyle = '#ffffff'
+    ctx.font = labelFont
+    const displayText = `${field.label}：${field.value}`
+    currentY = wrapText(ctx, displayText, marginX, currentY, contentWidth, lineHeight, maxLines)
+    currentY += 10 // 欄位間距
+  }
+
+  // ── 5. Footer 區域 ──
+  const footerY = CANVAS_HEIGHT - 260
+
+  // 分隔線
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.2)'
+  ctx.fillRect(marginX, footerY, contentWidth, 1)
+
+  // "歡迎點擊連結成為老師接案"
+  ctx.fillStyle = '#f0f7ed'
+  ctx.font = 'bold 36px "PingFang TC", "Noto Sans TC", sans-serif'
+  ctx.fillText('歡迎點擊連結成為老師接案', marginX, footerY + 60)
+
+  // 網址與 IG handle
+  ctx.font = 'bold 28px "Helvetica Neue", "PingFang TC", sans-serif'
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.8)'
+  ctx.fillText('WWW.TUTOR-MATCHING.TW', marginX, footerY + 120)
+  ctx.fillText('@PEPPERTEACHER.TW', marginX, footerY + 165)
+
+  // ── 6. 青椒老師 Logo ──
+  try {
+    const logo = await loadImage('/teacher-icon.png')
+    const logoSize = 180
+    ctx.drawImage(
+      logo,
+      CANVAS_WIDTH - marginX - logoSize,
+      CANVAS_HEIGHT - 300,
+      logoSize,
+      logoSize,
+    )
+  } catch {
+    // Logo 載入失敗不影響主要功能，靜默跳過
+    console.warn('Failed to load teacher icon for IG story')
+  }
+
+  // ── 7. 匯出為 PNG Blob ──
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob)
+        else reject(new Error('Canvas toBlob failed'))
+      },
+      'image/png',
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- 在 admin 案件搜尋結果右側欄新增「行銷工具」卡片，包含兩個按鈕
- **產生 IG Story 圖片**：Canvas API 繪製 1080×1920 PNG（品牌綠色漸層 + 案件資訊 + 青椒老師 Logo），自動下載 + 開新分頁預覽
- **複製 Dcard 貼文**：彈出可編輯的預覽 Dialog，修改完畢後一鍵複製標題與內文到剪貼簿
- 修正 gender 顯示問題（DB 存 male/female → 轉為 男/女）

## Test plan
- [x] 在 admin 搜尋一個案件，確認右側出現「行銷工具」卡片
- [x] 點「產生 IG Story 圖片」→ 自動下載 PNG + 新分頁顯示 1080×1920 圖片
- [x] 點「複製 Dcard 貼文」→ 彈出 Dialog，可編輯標題與內文，點「複製全部」成功複製
- [x] 驗證性別顯示為中文（男/女）而非英文

🤖 Generated with [Claude Code](https://claude.com/claude-code)